### PR TITLE
File extension logic cleanup

### DIFF
--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -81,7 +81,7 @@ def file_type_on_whitelist(config, s):
     if len(whitelist) == 0:
         logger.warn("Empty whitelist, check ruleset config.")
 
-    if set(s.mimetypes).issubset(set(whitelist)):
+    if s.mimetypes.issubset(set(whitelist)):
         return RuleResult(position,
                           result=Result.ignored,
                           reason="Dateityp ist auf Whitelist",
@@ -102,7 +102,7 @@ def file_type_on_greylist(config, s):
     if len(greylist) == 0:
         logger.warn("Empty greylist, check ruleset config.")
 
-    if set(s.mimetypes).issubset(set(greylist)):
+    if s.mimetypes.issubset(set(greylist)):
         return RuleResult(position,
                           result=Result.unknown,
                           reason="Dateityp ist auf der Liste der zu analysiserenden Typen",

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -307,17 +307,21 @@ class Sample(object):
 
     @property
     def file_extension(self):
+        if self.has_attr('file_extension'):
+            return self.get_attr('file_extension')
+
+        # try to find a file name containing an extension. Using
+        # self.__filename will almost never yield anything useful because
+        # amavis intentionally hands us files named only p001, p002 and so on.
+        # But we still try it in case there's no declared name.
+        filename = self.__filename
         if self.has_attr('meta_info_name_declared'):
-            file_ext = os.path.splitext(self.get_attr('meta_info_name_declared'))[1][1:]
-            if self.has_attr('file_extension'):
-                if self.get_attr('file_extension') != file_ext:
-                    self.set_attr('file_extension', file_ext, override=True)
-            else:
-                self.set_attr('file_extension', file_ext)
-        elif not self.has_attr('file_extension'):
-            file_ext = os.path.splitext(self.__filename)[1][1:]
-            self.set_attr('file_extension', file_ext)
-        return self.get_attr('file_extension')
+            filename = self.get_attr('meta_info_name_declared')
+
+        # extension or the empty string if none found
+        file_ext = os.path.splitext(filename)[1][1:]
+        self.set_attr('file_extension', file_ext)
+        return file_ext
 
     @property
     def mimetypes(self):

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -132,8 +132,11 @@ class Sample(object):
 
         # create a symlink to submit the file with the correct file extension
         # to cuckoo via submit.py.
+        file_ext = self.file_extension
+        if file_ext:
+            file_ext = ".%s" % file_ext
         self.__symlink = os.path.join(self.__wd,
-                '%s.%s' % (self.sha256sum, self.file_extension))
+                '%s%s' % (self.sha256sum, file_ext))
         logger.debug('ln -s %s %s' % (self.__path, self.__symlink))
         try:
             os.symlink(self.__path, self.__symlink)

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -334,7 +334,7 @@ class Sample(object):
         determine mime on original p[0-9]* file
         later result will be "inode/symlink"
         """
-        mime_types = []
+        mime_types = set()
 
         smime = {
             'p7s': [
@@ -350,7 +350,7 @@ class Sample(object):
             declared_mt = self.get_attr('meta_info_type_declared')
             if declared_mt is not None:
                 logger.debug('Sample declared as "%s"' % declared_mt)
-                mime_types.append(declared_mt)
+                mime_types.add(declared_mt)
         except Exception as e:
             logger.exception(e)
             declared_mt = None
@@ -362,19 +362,19 @@ class Sample(object):
             declared_filename = self.__filename
 
         content_based_mime_type = guess_mime_type_from_file_contents(self.__path)
-        if content_based_mime_type is not None and content_based_mime_type not in mime_types:
-            mime_types.append(content_based_mime_type)
+        if content_based_mime_type is not None:
+            mime_types.add(content_based_mime_type)
 
         name_based_mime_type = guess_mime_type_from_filename(declared_filename)
-        if name_based_mime_type is not None and name_based_mime_type not in mime_types:
-            mime_types.append(name_based_mime_type)
+        if name_based_mime_type is not None:
+            mime_types.add(name_based_mime_type)
 
         logger.debug('Determined MIME Types: %s' % mime_types)
         # check if the sample is an S/MIME signature (smime.p7s)
         # If so, don't overwrite the MIME type since we do not want to analyse S/MIME signatures.
         if declared_filename == 'smime.p7s' and declared_mt in smime['p7s']:
             logger.info('S/MIME signature detected. Using declared MIME type over detected ones.')
-            mime_types = [declared_mt]
+            mime_types = set([declared_mt])
 
         if not self.has_attr('mimetypes'):
             self.set_attr('mimetypes', mime_types)

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -459,12 +459,13 @@ class Sample(object):
         if not self.__wd:
             return
 
+        if self.__keep_mail_data:
+            logger.debug('Keeping mail data in %s' % self.__wd)
+            return
+
+        logger.debug("Deleting tempdir %s" % self.__wd)
         try:
-            if self.__keep_mail_data:
-                logger.debug('Keeping mail data in %s' % self.__wd)
-            else:
-                logger.debug("Deleting tempdir %s" % self.__wd)
-                shutil.rmtree(self.__wd)
+            shutil.rmtree(self.__wd)
         except OSError as e:
             logger.exception(e)
 

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -308,7 +308,7 @@ class Sample(object):
     @property
     def file_extension(self):
         if self.has_attr('meta_info_name_declared'):
-            file_ext = self.get_attr('meta_info_name_declared').split('.')[-1]
+            file_ext = os.path.splitext(self.get_attr('meta_info_name_declared'))[1][1:]
             if self.has_attr('file_extension'):
                 if self.get_attr('file_extension') != file_ext:
                     self.set_attr('file_extension', file_ext, override=True)

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -141,10 +141,7 @@ class Sample(object):
                     '%s.%s' % (self.sha256sum, file_ext))
 
             logger.debug('ln -s %s %s' % (self.__path, self.__submit_path))
-            try:
-                os.symlink(self.__path, self.__submit_path)
-            except OSError:
-                pass
+            os.symlink(self.__path, self.__submit_path)
 
         self.initialized = True
 

--- a/peekaboo/toolbox/files.py
+++ b/peekaboo/toolbox/files.py
@@ -36,8 +36,10 @@ logger = logging.getLogger(__name__)
 def guess_mime_type_from_file_contents(file_path):
     """  Get type from file magic bytes. """
     mt = magic.from_file(file_path, mime=True)
-    if mt:
-        return mt
+    if not mt:
+        return None
+
+    return mt
 
 
 def guess_mime_type_from_filename(file_path):
@@ -47,5 +49,7 @@ def guess_mime_type_from_filename(file_path):
         mimetypes.add_type('application/javascript', '.jse')
 
     mt = mimetypes.guess_type(file_path)[0]
-    if mt:
-        return mt
+    if not mt:
+        return None
+
+    return mt


### PR DESCRIPTION
Hi, I took a crack at guessing file extensions from mime types.

This lead to various cleanup in preparation to it, e.g. avoiding a trailing dot if we have no extension and only creating the workdir and symlink if we do have one to work with.

The guesswork itself is somewhat overenthusiastic in that it returns e.g. .ksh for text/plain. Otherwise it works fine, coming back with e.g. .py for text/x-python.

So I put this up for testing and comments for the time being.