### PR TITLE
Fix custom protocol call parameter grafting

### DIFF
--- a/amavis/10-ask_peekaboo
+++ b/amavis/10-ask_peekaboo
@@ -88,8 +88,16 @@ sub ask_peekaboo_internal {
 # it contains those, either because of empty hashes formatted as {} or just a
 # simple file name containing the sequence.
 sub ask_peekaboo {
-  $_[4] = \&ask_peekaboo_internal;
-  Amavis::AV::run_av(@_);
+  my (@run_av_args) = @_;
+
+  # be sure to patch a copy and not @_ because this would change the referenced
+  # call parameter and make the next call to us go directly to _internal
+  # instead, resulting in error messages like: Peekaboo-Analysis av-scanner
+  # FAILED: Can't use string ("/var/lib/amavis/tmp/amavis-20180"...) as a HASH
+  # ref while "strict refs" in use at /etc/amavis/conf.d/10-ask_peekaboo line
+  # 61.
+  $run_av_args[4] = \&ask_peekaboo_internal;
+  Amavis::AV::run_av(@run_av_args);
 }
 
 1;  # ensure a defined return value


### PR DESCRIPTION
Changing @_ is a bad idea because Perl is call-by-reference and changing
an element of @_ doesn't replace the reference in that array element
with another but changes the referenced object's value. In our case, due
to the internals of amavis, this would make the next call that should go
to ask_peekaboo go completely around it and run_av and directly into
ask_peekaboo_internal which would choke on the wrong argument data
types. The seeming nondeterminism of this is aggravated by the fact that
amavis' children and objects seem to have a lifetime after which they
would revert to a sane state, masking the problem.