### PR TITLE
Remove cuckoo report wrapper functions

### DIFF
--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -193,7 +193,7 @@ def requests_evil_domain(config, s):
 
     evil_domains = config['requests_evil_domain']['domain']
 
-    for d in s.requested_domains:
+    for d in s.cuckoo_report.requested_domains:
         if d in evil_domains:
             return RuleResult(position,
                               result=Result.bad,
@@ -211,7 +211,7 @@ def cuckoo_analysis_failed(config, s):
     tb = tb[-1]
     position = "%s:%s" % (tb[2], tb[1])
 
-    if s.cuckoo_analysis_failed:
+    if s.cuckoo_report.analysis_failed:
         return RuleResult(position,
                           result=Result.bad,
                           reason="Die Verhaltensanalyse durch Cuckoo hat einen Fehler Produziert und konnte nicht erfolgreich abgeschlossen werden",

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -372,18 +372,6 @@ class Sample(object):
         return self.get_attr('analyses_time')
 
     @property
-    def requested_domains(self):
-        if not self.has_attr('requested_domains'):
-            try:
-                self.set_attr(
-                    'requested_domains',
-                    self.get_attr('cuckoo_report').requested_domains
-                )
-            except KeyError:
-                self.set_attr('requested_domains', [])
-        return self.get_attr('requested_domains')
-
-    @property
     def cuckoo_report(self):
         if not self.has_attr('cuckoo_report'):
             try:
@@ -401,17 +389,6 @@ class Sample(object):
             except CuckooAnalysisFailedException as e:
                 logger.exception(e)
         return self.get_attr('cuckoo_report')
-
-    @property
-    def cuckoo_analysis_failed(self):
-        if not self.has_attr('cuckoo_failed'):
-            if self.has_attr('cuckoo_report'):
-                report = self.get_attr('cuckoo_report')
-                if report.analysis_failed:
-                    self.set_attr('cuckoo_failed', True)
-                else:
-                    self.set_attr('cuckoo_failed', False)
-        return self.get_attr('cuckoo_failed')
 
     def __close_socket(self):
         logger.debug('Closing socket connection.')


### PR DESCRIPTION
Remove the wrappers for Cuckoo report's failed analysis and requested
domains indicators and use the cuckoo_report property of Sample
directly. This restores the self-organising property of samples in that
the first call to cuckoo_report will trigger the submit to Cuckoo,
allowing for reordering of Cuckoo rules accessing the report without
changes to Sample. Also, it removes some boilerplate code as well as
otherwise unused sample attributes.

@Jack28: Do you remember why this was wrapped in the first place? Was there some concurrency problem with the automatic submit from Sample on first request of the Cuckoo report? Unfortunately git blame doesn't help because this was already in place on first import to git.