### PR TITLE
Fix and optimise inProgress cleanup at startup

### DIFF
--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -413,6 +413,7 @@ class PeekabooDatabase(object):
             session.query(AnalysisJournal).filter_by(
                 sample=in_progress_sample
             ).delete()
+        session.query(SampleInfo).filter_by(result=in_progress).delete()
         try:
             session.commit()
             logger.debug('Cleared the database from "inProgress" entries.')

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -406,14 +406,19 @@ class PeekabooDatabase(object):
             AnalysisResult,
             name='inProgress'
         )
-        in_progress_samples = session.query(SampleInfo).filter_by(
-            result=in_progress
-        ).all()
-        for in_progress_sample in in_progress_samples:
-            session.query(AnalysisJournal).filter_by(
-                sample=in_progress_sample
-            ).delete()
-        session.query(SampleInfo).filter_by(result=in_progress).delete()
+        in_progress_samples = session.query(SampleInfo).filter_by(result=in_progress)
+        # The direct approach does not work currently with message:
+        #   in_() not yet supported for relationships.  For a simple many-to-one,
+        #   use in_() against the set of foreign key values.
+        # This is what we do below.
+        #session.query(AnalysisJournal).filter(
+        #        AnalysisJournal.sample.in_(in_progress_samples)).delete()
+        sample_ids = [s.id for s in in_progress_samples.all()]
+        if sample_ids:
+            session.query(AnalysisJournal).filter(
+                    AnalysisJournal.sample_id.in_(sample_ids)
+                ).delete(synchronize_session = False)
+            in_progress_samples.delete()
         try:
             session.commit()
             logger.debug('Cleared the database from "inProgress" entries.')


### PR DESCRIPTION
These changes fix a bug where startup would gradually slow down because we weren't clearing all database objects left in unfinished from a previous run and try to be more efficient on the actual cleanup.