### PR TITLE
Do not freeze dependency software versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-sqlalchemy==1.0.8
+sqlalchemy>=1.0.8
 Twisted>=17.1.0
 service_identity>=16.0.0
-python-magic==0.4.12
-oletools==0.51
-sdnotify==0.3.1
-enum34==1.0.4
-yara-python==3.6.3
-requests==2.19.1
+python-magic>=0.4.12
+oletools>=0.51
+sdnotify>=0.3.1
+enum34>=1.0.4
+yara-python>=3.6.3
+requests>=2.19.0


### PR DESCRIPTION
Allow dependencies to be more current than our minimum requirements,
particularly to allow security-fixed updated versions to be used.
Spotted by GitHub for requests and also affecting yara.

Closes #51.