### PR TITLE
Db concurrency

### DIFF
--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -56,6 +56,11 @@ url              :    sqlite:////path/to/database.db
 # ID will corrupt each others' records and there is no mechanism to detect this.
 instance_id: 0
 
+# number of seconds after which in-flight markers of samples are to be
+# removed/ignored, assuming that the instance processing them has crashed or
+# been shut down.
+stale_in_flight_threshold: 3600
+
 #
 # Cuckoo specific settings
 #

--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -48,19 +48,6 @@ url              :    sqlite:////path/to/database.db
 # PostgreSQL
 # url             :    postgresql://user:password@host:port/database
 
-# if multiple instances are to run in parallel and avoid concurrent analysis of
-# the same sample, set instance_id to a nonzero positive unique integer value
-# on each instance and use the same networked DBMS instance (MySQL or
-# PostgreSQL) for all them. (SQLite is not a good choice for this.) Also, do
-# make really, really sure to provide unique IDs. Two instances using the same
-# ID will corrupt each others' records and there is no mechanism to detect this.
-instance_id: 0
-
-# number of seconds after which in-flight markers of samples are to be
-# removed/ignored, assuming that the instance processing them has crashed or
-# been shut down.
-stale_in_flight_threshold: 3600
-
 #
 # Cuckoo specific settings
 #
@@ -79,3 +66,21 @@ url              :    http://127.0.0.1:8090
 poll_interval    :    5
 
 storage_path     :    /home/peekaboo/.cuckoo/storage
+
+[cluster]
+# if multiple instances are to run in parallel and avoid concurrent analysis of
+# the same sample, set instance_id to a nonzero positive unique integer value
+# on each instance and use the same networked DBMS instance (MySQL or
+# PostgreSQL) for all them. (SQLite is not a good choice for this.) Also, do
+# make really, really sure to provide unique IDs. Two instances using the same
+# ID will corrupt each others' records and there is no mechanism to detect this.
+instance_id: 0
+
+# number of seconds after which in-flight markers of samples are to be
+# removed/ignored, assuming that the instance processing them has crashed or
+# been shut down.
+stale_in_flight_threshold: 3600
+
+# Interval in which to check if other instances of a Peekaboo cluster have
+# finished processing samples we have held.
+duplicate_check_interval: 60

--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -48,6 +48,13 @@ url              :    sqlite:////path/to/database.db
 # PostgreSQL
 # url             :    postgresql://user:password@host:port/database
 
+# if multiple instances are to run in parallel and avoid concurrent analysis of
+# the same sample, set instance_id to a nonzero positive unique integer value
+# on each instance and use the same networked DBMS instance (MySQL or
+# PostgreSQL) for all them. (SQLite is not a good choice for this.) Also, do
+# make really, really sure to provide unique IDs. Two instances using the same
+# ID will corrupt each others' records and there is no mechanism to detect this.
+instance_id: 0
 
 #
 # Cuckoo specific settings

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -54,6 +54,7 @@ class PeekabooConfig(object):
         self.keep_mail_data = None
         self.db_url = None
         self.instance_id = 0
+        self.stale_in_flight_threshold = 1*60*60
         self.ruleset_config = None
         self.cuckoo_mode = "api"
         self.cuckoo_url = ""
@@ -91,6 +92,8 @@ class PeekabooConfig(object):
             ) == 'yes' else False
             self.db_url = config.get('db', 'url')
             self.instance_id = int(config.get('db', 'instance_id'))
+            self.stale_in_flight_threshold = int(config.get('db',
+                'stale_in_flight_threshold'))
             self.ruleset_config = config.get('ruleset', 'config')
             self.cuckoo_mode = config.get('cuckoo', 'mode')
             self.cuckoo_url = config.get('cuckoo', 'url')

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -53,8 +53,6 @@ class PeekabooConfig(object):
         self.use_debug_module = None
         self.keep_mail_data = None
         self.db_url = None
-        self.instance_id = 0
-        self.stale_in_flight_threshold = 1*60*60
         self.ruleset_config = None
         self.cuckoo_mode = "api"
         self.cuckoo_url = ""
@@ -62,6 +60,9 @@ class PeekabooConfig(object):
         self.cuckoo_storage = None
         self.cuckoo_exec = None
         self.cuckoo_submit = None
+        self.cluster_instance_id = 0
+        self.cluster_stale_in_flight_threshold = 1*60*60
+        self.cluster_duplicate_check_interval = 60
         ##############################################
         # setup default logging to log any errors during the
         # parsing of the config file.
@@ -91,9 +92,6 @@ class PeekabooConfig(object):
                 'global', 'keep_mail_data'
             ) == 'yes' else False
             self.db_url = config.get('db', 'url')
-            self.instance_id = int(config.get('db', 'instance_id'))
-            self.stale_in_flight_threshold = int(config.get('db',
-                'stale_in_flight_threshold'))
             self.ruleset_config = config.get('ruleset', 'config')
             self.cuckoo_mode = config.get('cuckoo', 'mode')
             self.cuckoo_url = config.get('cuckoo', 'url')
@@ -101,6 +99,11 @@ class PeekabooConfig(object):
             self.cuckoo_storage = config.get('cuckoo', 'storage_path')
             self.cuckoo_exec = config.get('cuckoo', 'exec')
             self.cuckoo_submit = config.get('cuckoo', 'submit').split(' ')
+            self.cluster_instance_id = config.getint('cluster', 'instance_id')
+            self.cluster_stale_in_flight_threshold = config.getint(
+                'cluster', 'stale_in_flight_threshold')
+            self.cluster_duplicate_check_interval = config.getint(
+                'cluster', 'duplicate_check_interval')
             # Update logging with what we just parsed from the config
             self.__setup_logging()
         except NoSectionError as e:

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -53,6 +53,7 @@ class PeekabooConfig(object):
         self.use_debug_module = None
         self.keep_mail_data = None
         self.db_url = None
+        self.instance_id = 0
         self.ruleset_config = None
         self.cuckoo_mode = "api"
         self.cuckoo_url = ""
@@ -89,6 +90,7 @@ class PeekabooConfig(object):
                 'global', 'keep_mail_data'
             ) == 'yes' else False
             self.db_url = config.get('db', 'url')
+            self.instance_id = int(config.get('db', 'instance_id'))
             self.ruleset_config = config.get('ruleset', 'config')
             self.cuckoo_mode = config.get('cuckoo', 'mode')
             self.cuckoo_url = config.get('cuckoo', 'url')

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -316,7 +316,7 @@ def run():
     # Factory producing almost identical samples providing them with global
     # config values and references to other objects they need, such as cuckoo,
     # database connection and connection map.
-    sample_factory = SampleFactory(cuckoo, db_con, connection_map,
+    sample_factory = SampleFactory(cuckoo, connection_map,
                 config.sample_base_dir, config.job_hash_regex,
                 config.keep_mail_data)
 

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -252,7 +252,7 @@ def run():
 
     # establish a connection to the database
     try:
-        db_con = PeekabooDatabase(config.db_url)
+        db_con = PeekabooDatabase(config.db_url, config.instance_id)
     except PeekabooDatabaseError as e:
         logging.exception(e)
         sys.exit(1)
@@ -350,6 +350,7 @@ def run():
         server.shutdown()
         server.server_close()
         job_queue.shut_down()
+        db_con.clear_in_flight_samples()
         if debugger is not None:
             debugger.shut_down()
 

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -213,19 +213,6 @@ class PeekabooDatabase(object):
             finally:
                 session.close()
 
-    def sample_info_exists(self, sample):
-        """
-        Check if a log for a given sample exists.
-
-        :param sample: The Sample object to check.
-        """
-        with self.__lock:
-            return self.__exists(
-                SampleInfo,
-                sha256sum=sample.sha256sum,
-                file_extension=sample.file_extension
-            )
-
     def sample_info_fetch(self, sample):
         """
         Fetch information stored in the database about a given sample object.
@@ -503,21 +490,6 @@ class PeekabooDatabase(object):
             )
         finally:
             session.close()
-
-    def __exists(self, model, **kwargs):
-        """
-        Check whether an ORM instance exists.
-
-        :param session: An SQLAlchemy session object.
-        :param model: The model to query.
-        :return: True if the ORM instance exists otherwise False.
-        """
-        session = self.__Session()
-        instance = PeekabooDatabase.__get(session, model, **kwargs)
-        session.close()
-        if instance is not None:
-            return True
-        return False
 
     @staticmethod
     def __get_or_create(session, model, **kwargs):

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -233,14 +233,14 @@ class PeekabooDatabase(object):
         :param start_time: Override the time the marker was placed for
                            debugging purposes.
         """
+        # an instance id of 0 denotes that we're alone and don't need to track
+        # in-flight samples in the database
+        if self.instance_id == 0:
+            return True
+
         # use our own instance id if none is given
         if instance_id is None:
             instance_id = self.instance_id
-
-        # an instance id of 0 denotes that we're alone and don't need to track
-        # in-flight samples in the database
-        if instance_id == 0:
-            return True
 
         if start_time is None:
             start_time = datetime.utcnow()
@@ -280,14 +280,14 @@ class PeekabooDatabase(object):
         :param instance_id: (optionally) The ID of the instance that is
                             handling this sample. Default: Us.
         """
+        # an instance id of 0 denotes that we're alone and don't need to track
+        # in-flight samples in the database
+        if self.instance_id == 0:
+            return
+
         # use our own instance id if none is given
         if instance_id is None:
             instance_id = self.instance_id
-
-        # an instance id of 0 denotes that we're alone and don't need to track
-        # in-flight samples in the database
-        if instance_id == 0:
-            return
 
         session = self.__Session()
 
@@ -323,18 +323,18 @@ class PeekabooDatabase(object):
         Clear all in-flight markers left over by previous runs or other
         instances by removing them from the lock table.
 
-        @instance_id: Clear our own (None), another instance's (positive
-                      integer), all instances' (negative integer) locks or do
-                      nothing (0).
+        :param instance_id: Clear our own (None), another instance's (positive
+                            integer), all instances' (negative integer) locks
+                            or do nothing (0).
         """
+        # an instance id of 0 denotes that we're alone and don't need to track
+        # in-flight samples
+        if self.instance_id == 0:
+            return
+
         # use our own instance id if none is given
         if instance_id is None:
             instance_id = self.instance_id
-
-        # an instance id of 0 denotes that we're alone and don't need to track
-        # in-flight samples
-        if instance_id == 0:
-            return
 
         session = self.__Session()
 
@@ -363,6 +363,11 @@ class PeekabooDatabase(object):
         Clear all in-flight markers that are too old and therefore stale. This
         detects instances which are locked up, crashed or shut down.
         """
+        # an instance id of 0 denotes that we're alone and don't need to track
+        # in-flight samples in the database
+        if self.instance_id == 0:
+            return True
+
         session = self.__Session()
 
         # delete only the locks of a specific instance

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -30,7 +30,7 @@ from sqlalchemy.engine import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session, relationship
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from peekaboo import __version__
-from peekaboo.ruleset import Result, RuleResult
+from peekaboo.ruleset import Result
 from peekaboo.exceptions import PeekabooDatabaseError
 import threading
 import logging
@@ -191,7 +191,7 @@ class PeekabooDatabase(object):
                 sha256sum=sample.sha256sum,
                 file_extension=sample.file_extension,
                 result=sample.get_result(),
-                reason=sample.reason)
+                reason=sample.get_reason())
 
         analysis.sample = sample_info
 
@@ -222,30 +222,6 @@ class PeekabooDatabase(object):
                 file_extension=sample.file_extension).first()
             session.close()
         return sample_info
-
-    def fetch_rule_result(self, sample):
-        """
-        Gets the sample information from the database as a RuleResult object.
-
-        :param sample: The Sample object to get the rule result from.
-        :return: Returns a RuleResult object containing the sample information.
-        """
-        sample_info = self.sample_info_fetch(sample)
-        if sample_info:
-            result = RuleResult(
-                'db',
-                result=sample_info.result,
-                reason=sample_info.reason,
-                further_analysis=True
-            )
-        else:
-            result = RuleResult(
-                'db',
-                result=Result.unknown,
-                reason="Datei ist dem System noch nicht bekannt",
-                further_analysis=True
-            )
-        return result
 
     def known(self, sample):
         """

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -400,7 +400,14 @@ class PeekabooDatabase(object):
             return False
         else:
             session = self.__Session()
-            meta = session.query(PeekabooMetadata)[-1]
+            # get the first of potentially multiple metadata entries ordered by
+            # descending schema version to get the newest currently configured
+            # schema
+            meta = session.query(PeekabooMetadata).order_by(
+                PeekabooMetadata.db_schema_version.desc()).first()
+            if not meta:
+                return False
+
             schema_version = meta.db_schema_version
             session.close()
             if schema_version < DB_SCHEMA_VERSION:

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -223,16 +223,6 @@ class PeekabooDatabase(object):
             session.close()
         return sample_info
 
-    def known(self, sample):
-        """
-        Check if we already have a sample in the database by its SHA-256 hash.
-
-        :param sample: The Sample object to check.
-        """
-        sample_info = self.sample_info_fetch(sample)
-        is_known = sample_info is not None
-        return is_known
-
     def mark_sample_in_flight(self, sample, instance_id=None, start_time=None):
         """
         Mark a sample as in flight, i.e. being worked on by an instance.

--- a/peekaboo/queuing.py
+++ b/peekaboo/queuing.py
@@ -118,7 +118,7 @@ class JobQueue:
             else:
                 # are we the first of potentially multiple instances working on
                 # this sample?
-                if sample.mark_as_in_flight():
+                if self.db_con.mark_sample_in_flight(sample):
                     # initialise a per-duplicate backlog for this sample which
                     # also serves as in-flight marker and submit to queue
                     self.duplicates[sample_hash] = {
@@ -158,7 +158,7 @@ class JobQueue:
             # processed by another instance concurrently
             for sample_hash, sample_duplicates in self.cluster_duplicates.items():
                 # try to mark as in-flight
-                if sample_duplicates[0].mark_as_in_flight():
+                if self.db_con.mark_sample_in_flight(sample_duplicates[0]):
                     sample_str = str(sample_duplicates[0])
                     if self.duplicates.get(sample_hash) is not None:
                         logger.error("Possible backlog corruption for sample "
@@ -205,7 +205,7 @@ class JobQueue:
                 self.jobs.put(s, True, self.queue_timeout)
 
             sample = self.duplicates[sample_hash]['master']
-            sample.clear_in_flight()
+            self.db_con.clear_sample_in_flight(sample)
             sample_str = str(sample)
             del self.duplicates[sample_hash]
 

--- a/peekaboo/queuing.py
+++ b/peekaboo/queuing.py
@@ -298,7 +298,7 @@ class Worker(Thread):
             sample.init()
 
             try:
-                engine = RulesetEngine(sample, self.ruleset_config)
+                engine = RulesetEngine(sample, self.ruleset_config, self.db_con)
                 engine.run()
                 engine.report()
 

--- a/peekaboo/queuing.py
+++ b/peekaboo/queuing.py
@@ -302,15 +302,8 @@ class Worker(Thread):
                 engine.run()
                 engine.report()
 
-                # save analysis result to database if not known already
-                # FIXME: If check for known samples is an optional rule, should
-                # persisting the analysis result be optional as well?
-                if not self.db_con.known(sample):
-                    logger.debug('Saving results to database')
-                    self.db_con.analysis_save(sample)
-                else:
-                    logger.debug('Known sample info not logged to database')
-
+                logger.debug('Saving results to database')
+                self.db_con.analysis_save(sample)
                 sample.remove_from_connection_map()
 
                 self.job_queue.done(sample.sha256sum)

--- a/peekaboo/ruleset/__init__.py
+++ b/peekaboo/ruleset/__init__.py
@@ -39,18 +39,15 @@ class Result(Enum):
     good = 5
     bad = 6
 
-    @staticmethod
-    def from_string(result_str):
-        for i in Result:
-            if i.name == result_str:
-                return i
-        raise ValueError('%s: Element not found' % result_str)
+    def __ge__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value >= other.value
+        return NotImplemented
 
-    def __gt__(self, other):
-        return self.value >= other.value
-
-    def __lt__(self, other):
-        return other.value >= self.value
+    def __le__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value <= other.value
+        return NotImplemented
 
 
 class RuleResult:

--- a/peekaboo/ruleset/__init__.py
+++ b/peekaboo/ruleset/__init__.py
@@ -32,7 +32,6 @@ class Result(Enum):
     """
     @author: Felix Bauer
     """
-    inProgress = 0
     unchecked = 1
     unknown = 2
     ignored = 3

--- a/peekaboo/ruleset/engine.py
+++ b/peekaboo/ruleset/engine.py
@@ -58,9 +58,10 @@ class RulesetEngine(object):
         FinalRule
     ]
 
-    def __init__(self, sample, ruleset_config):
+    def __init__(self, sample, ruleset_config, db_con):
         self.sample = sample
         self.config = ruleset_config
+        self.db_con = db_con
 
     def run(self):
         for rule in RulesetEngine.rules:
@@ -89,7 +90,7 @@ class RulesetEngine(object):
                 # guaranteed to be a hash, albeit empty if no rule config
                 # exists
                 rule_config = self.config.rule_config(rule_name)
-                rule = rule_class(rule_config)
+                rule = rule_class(config=rule_config, db_con=self.db_con)
                 result = rule.evaluate(sample)
             else:
                 logger.debug("Rule '%s' is disabled." % rule_name)

--- a/peekaboo/ruleset/engine.py
+++ b/peekaboo/ruleset/engine.py
@@ -75,7 +75,6 @@ class RulesetEngine(object):
         self.sample.report()
         if self.sample.get_result() == Result.bad:
             dump_processing_info(self.sample)
-        self.sample.save_result()
 
     def __exec_rule(self, config, sample, rule_function):
         """

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -33,8 +33,9 @@ logger = logging.getLogger(__name__)
 
 
 class Rule(object):
-    def __init__(self, config):
+    def __init__(self, config=None, db_con=None):
         self.config = config
+        self.db_con = db_con
 
     def result(self, result, reason, further_analysis):
         return RuleResult(self.rule_name, result=result, reason=reason,
@@ -44,7 +45,7 @@ class KnownRule(Rule):
     rule_name = 'known'
 
     def evaluate(self, s):
-        sample_info = s.info_from_db
+        sample_info = self.db_con.sample_info_fetch(s)
         if sample_info:
             return self.result(sample_info.result, sample_info.reason, False)
 

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -96,11 +96,11 @@ class FileTypeOnWhitelistRule(Rule):
         """ Ignore the file only if *all* of its mime types are on the
         whitelist and we could determine at least one. """
         whitelist = self.config.get('whitelist', ())
-        if len(whitelist) == 0:
+        if not whitelist:
             logger.warn("Empty whitelist, check ruleset config.")
             return self.result(Result.unknown, "Whitelist ist leer", True)
 
-        if len(s.mimetypes) > 0 and s.mimetypes.issubset(set(whitelist)):
+        if s.mimetypes and s.mimetypes.issubset(set(whitelist)):
             return self.result(Result.ignored,
                                "Dateityp ist auf Whitelist",
                                False)
@@ -119,11 +119,11 @@ class FileTypeOnGreylistRule(Rule):
         """ Continue analysis if any of the sample's MIME types are on the
         greylist or in case we don't have one. """
         greylist = self.config.get('greylist', ())
-        if len(greylist) == 0:
+        if not greylist:
             logger.warn("Empty greylist, check ruleset config.")
             return self.result(Result.unknown, "Greylist is leer", False)
 
-        if len(s.mimetypes.intersection(set(greylist))) > 0 or len(s.mimetypes) == 0:
+        if not s.mimetypes or s.mimetypes.intersection(set(greylist)):
             return self.result(Result.unknown,
                                "Dateityp ist auf der Liste der zu "
                                "analysiserenden Typen",
@@ -146,7 +146,7 @@ class CuckooEvilSigRule(Rule):
         # list all installed signatures
         # grep -o "description.*" -R . ~/cuckoo2.0/modules/signatures/
         bad_sigs = self.config.get('signature', ())
-        if len(bad_sigs) == 0:
+        if not bad_sigs:
             logger.warn("Empty bad signature list, check ruleset config.")
             return self.result(Result.unknown,
                                "Leere Liste schaedlicher Signaturen",
@@ -166,7 +166,7 @@ class CuckooEvilSigRule(Rule):
             if match:
                 matched_bad_sigs.append(sig)
 
-        if len(matched_bad_sigs) == 0:
+        if not matched_bad_sigs:
             return self.result(Result.unknown,
                                "Keine Signatur erkannt die auf Schadcode "
                                "hindeutet",
@@ -226,7 +226,7 @@ class RequestsEvilDomainRule(Rule):
         """ Report the sample as bad if one of the requested domains is on our
         list of evil domains. """
         evil_domains = self.config.get('domain', ())
-        if len(evil_domains) == 0:
+        if not evil_domains:
             logger.warn("Empty evil domain list, check ruleset config.")
             return self.result(Result.unknown, "Leere Domainliste", True)
 

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -24,7 +24,6 @@
 ###############################################################################
 
 
-import traceback
 import re
 import logging
 from peekaboo.ruleset import Result, RuleResult
@@ -33,214 +32,205 @@ from peekaboo.ruleset import Result, RuleResult
 logger = logging.getLogger(__name__)
 
 
-def known(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
+class Rule(object):
+    def __init__(self, config):
+        self.config = config
 
-    sample_info = s.info_from_db
-    if sample_info:
-        return RuleResult(position,
-                          result=sample_info.result,
-                          reason=sample_info.reason,
-                          further_analysis=False)
+    def result(self, result, reason, further_analysis):
+        return RuleResult(self.rule_name, result=result, reason=reason,
+                          further_analysis=further_analysis)
 
-    return RuleResult(position,
-                      result=Result.unknown,
-                      reason="Datei ist dem System noch nicht bekannt",
-                      further_analysis=True)
+class KnownRule(Rule):
+    rule_name = 'known'
 
+    def evaluate(self, s):
+        sample_info = s.info_from_db
+        if sample_info:
+            return self.result(sample_info.result, sample_info.reason, False)
 
-def file_larger_than(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
-
-    size = int(config.get('bytes', 5))
-
-    if s.file_size > size:
-        return RuleResult(position,
-                          result=Result.unknown,
-                          reason="Datei hat mehr als %d bytes"
-                          % size,
-                          further_analysis=True)
-
-    return RuleResult(position,
-                      result=Result.ignored,
-                      reason="Datei ist nur %d bytes lang"
-                      % s.file_size,
-                      further_analysis=False)
+        return self.result(Result.unknown,
+                           "Datei ist dem System noch nicht bekannt",
+                           True)
 
 
-def file_type_on_whitelist(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
+class FileLargerThanRule(Rule):
+    rule_name = 'file_larger_than'
 
-    whitelist = config.get('whitelist', ())
-    if len(whitelist) == 0:
-        logger.warn("Empty whitelist, check ruleset config.")
+    def evaluate(self, s):
+        size = int(self.config.get('bytes', 5))
 
-    # ignore the file only if *all* of its mime types are on the whitelist and we could
-    # determin at least one
-    if len(s.mimetypes) > 0 and s.mimetypes.issubset(set(whitelist)):
-        return RuleResult(position,
-                          result=Result.ignored,
-                          reason="Dateityp ist auf Whitelist",
-                          further_analysis=False)
+        if s.file_size > size:
+            return self.result(Result.unknown,
+                               "Datei hat mehr als %d bytes" % size,
+                               True)
 
-    return RuleResult(position,
-                      result=Result.unknown,
-                      reason="Dateityp ist nicht auf Whitelist",
-                      further_analysis=True)
+        return self.result(Result.ignored,
+                           "Datei ist nur %d bytes lang" % s.file_size,
+                           False)
 
 
-def file_type_on_greylist(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
+class FileTypeOnWhitelistRule(Rule):
+    rule_name = 'file_type_on_whitelist'
 
-    greylist = config.get('greylist', ())
-    if len(greylist) == 0:
-        logger.warn("Empty greylist, check ruleset config.")
+    def evaluate(self, s):
+        whitelist = self.config.get('whitelist', ())
+        if len(whitelist) == 0:
+            logger.warn("Empty whitelist, check ruleset config.")
+            return self.result(Result.unknown, "Whitelist ist leer", True)
 
-    # continue analysis if any of the sample's mime types are on the greylist or in case
-    # we don't have one
-    if len(s.mimetypes.intersection(set(greylist))) > 0 or len(s.mimetypes) == 0:
-        return RuleResult(position,
-                          result=Result.unknown,
-                          reason="Dateityp ist auf der Liste der zu analysiserenden Typen",
-                          further_analysis=True)
+        # ignore the file only if *all* of its mime types are on the whitelist
+        # and we could determine at least one
+        if len(s.mimetypes) > 0 and s.mimetypes.issubset(set(whitelist)):
+            return self.result(Result.ignored,
+                               "Dateityp ist auf Whitelist",
+                               False)
 
-    return RuleResult(position,
-                      result=Result.unknown,
-                      reason="Dateityp ist nicht auf der Liste der zu analysierenden Typen (%s)"
-                      % (str(s.mimetypes)),
-                      further_analysis=False)
+        return self.result(Result.unknown,
+                           "Dateityp ist nicht auf Whitelist",
+                           True)
 
 
-def cuckoo_evil_sig(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
+class FileTypeOnGreylistRule(Rule):
+    rule_name = 'file_type_on_greylist'
 
-    # signatures that if matched mark a sample as bad
-    # list all installed signatures
-    # grep -o "description.*" -R . ~/cuckoo2.0/modules/signatures/
-    bad_sigs = config.get('signature', ())
-    if len(bad_sigs) == 0:
-        logger.warn("Empty bad signature list, check ruleset config.")
+    def evaluate(self, s):
+        greylist = self.config.get('greylist', ())
+        if len(greylist) == 0:
+            logger.warn("Empty greylist, check ruleset config.")
+            return self.result(Result.unknown, "Greylist is leer", False)
 
-    sigs = []
+        # continue analysis if any of the sample's mime types are on the greylist or in case
+        # we don't have one
+        if len(s.mimetypes.intersection(set(greylist))) > 0 or len(s.mimetypes) == 0:
+            return self.result(Result.unknown,
+                               "Dateityp ist auf der Liste der zu "
+                               "analysiserenden Typen",
+                               True)
 
-    # look through matched signatures
-    for descr in s.cuckoo_report.signatures:
-        logger.debug(descr['description'])
-        sigs.append(descr['description'])
-
-    # check if there is a "bad" signatures and return bad
-    matched_bad_sigs = []
-    for sig in bad_sigs:
-        match = re.search(sig, str(sigs))
-        if match:
-            matched_bad_sigs.append(sig)
-
-    if len(matched_bad_sigs) == 0:
-        return RuleResult(position,
-                          result=Result.unknown,
-                          reason="Keine Signatur erkannt die auf Schadcode hindeutet",
-                          further_analysis=True)
-
-    return RuleResult(position,
-                      result=Result.bad,
-                      reason="Folgende Signaturen wurden erkannt: %s"
-                      % ''.ljust(8).join(["%s\n" % s for s in matched_bad_sigs]),
-                      further_analysis=False)
+        return self.result(Result.unknown,
+                           "Dateityp ist nicht auf der Liste der zu "
+                           "analysierenden Typen (%s)" % (str(s.mimetypes)),
+                           False)
 
 
-def cuckoo_score(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
+class CuckooEvilSigRule(Rule):
+    rule_name = 'cuckoo_evil_sig'
 
-    threshold = float(config.get('higher_than', 4.0))
+    def evaluate(self, s):
+        # signatures that if matched mark a sample as bad
+        # list all installed signatures
+        # grep -o "description.*" -R . ~/cuckoo2.0/modules/signatures/
+        bad_sigs = self.config.get('signature', ())
+        if len(bad_sigs) == 0:
+            logger.warn("Empty bad signature list, check ruleset config.")
+            return self.result(Result.unknown,
+                               "Leere Liste schaedlicher Signaturen",
+                               True)
 
-    if s.cuckoo_report.score >= threshold:
-        return RuleResult(position,
-                          result=Result.bad,
-                          reason="Cuckoo score >= %s: %s"
-                          % (threshold, s.cuckoo_report.score),
-                          further_analysis=False)
+        sigs = []
 
-    return RuleResult(position,
-                      result=Result.unknown,
-                      reason="Cuckoo score < %s: %s"
-                      % (threshold, s.cuckoo_report.score),
-                      further_analysis=True)
+        # look through matched signatures
+        for descr in s.cuckoo_report.signatures:
+            logger.debug(descr['description'])
+            sigs.append(descr['description'])
 
+        # check if there is a "bad" signatures and return bad
+        matched_bad_sigs = []
+        for sig in bad_sigs:
+            match = re.search(sig, str(sigs))
+            if match:
+                matched_bad_sigs.append(sig)
 
-def office_macro(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
+        if len(matched_bad_sigs) == 0:
+            return self.result(Result.unknown,
+                               "Keine Signatur erkannt die auf Schadcode "
+                               "hindeutet",
+                               True)
 
-    if s.office_macros:
-        return RuleResult(position,
-                          result=Result.bad,
-                          reason="Die Datei beinhaltet ein Office-Makro",
-                          further_analysis=False)
-
-    return RuleResult(position,
-                      result=Result.unknown,
-                      reason="Die Datei beinhaltet kein erkennbares Office-Makro",
-                      further_analysis=True)
-
-
-def requests_evil_domain(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
-
-    evil_domains = config.get('domain', ())
-    if len(evil_domains) == 0:
-        logger.warn("Empty evil domain list, check ruleset config.")
-
-    for d in s.cuckoo_report.requested_domains:
-        if d in evil_domains:
-            return RuleResult(position,
-                              result=Result.bad,
-                              reason="Die Datei versucht mindestens eine Domain aus der Blacklist zu kontaktieren (%s)" % d,
-                              further_analysis=False)
-
-    return RuleResult(position,
-                      result=Result.unknown,
-                      reason="Datei scheint keine Domains aus der Blacklist kontaktieren zu wollen",
-                      further_analysis=True)
+        matched = ''.ljust(8).join(["%s\n" % s for s in matched_bad_sigs])
+        return self.result(Result.bad,
+                           "Folgende Signaturen wurden erkannt: %s" % matched,
+                           False)
 
 
-def cuckoo_analysis_failed(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
+class CuckooScoreRule(Rule):
+    rule_name = 'cuckoo_score'
 
-    if s.cuckoo_report.analysis_failed:
-        return RuleResult(position,
-                          result=Result.bad,
-                          reason="Die Verhaltensanalyse durch Cuckoo hat einen Fehler Produziert und konnte nicht erfolgreich abgeschlossen werden",
-                          further_analysis=False)
+    def evaluate(self, s):
+        threshold = float(self.config.get('higher_than', 4.0))
 
-    return RuleResult(position,
-                      result=Result.unknown,
-                      reason="Die Verhaltensanalyse durch Cuckoo wurde erfolgreich abgeschlossen",
-                      further_analysis=True)
+        if s.cuckoo_report.score >= threshold:
+            return self.result(Result.bad,
+                               "Cuckoo score >= %s: %s" %
+                               (threshold, s.cuckoo_report.score),
+                               False)
+
+        return self.result(Result.unknown,
+                           "Cuckoo score < %s: %s" %
+                           (threshold, s.cuckoo_report.score),
+                           True)
 
 
-def final_rule(config, s):
-    tb = traceback.extract_stack()
-    tb = tb[-1]
-    position = "%s:%s" % (tb[2], tb[1])
+class OfficeMacroRule(Rule):
+    rule_name = 'office_macro'
 
-    return RuleResult(position,
-                      result=Result.unknown,
-                      reason="Datei scheint keine erkennbaren Schadroutinen zu starten",
-                      further_analysis=True)
+    def evaluate(self, s):
+        if s.office_macros:
+            return self.result(Result.bad,
+                               "Die Datei beinhaltet ein Office-Makro",
+                               False)
+
+        return self.result(Result.unknown,
+                           "Die Datei beinhaltet kein erkennbares "
+                           "Office-Makro",
+                           True)
+
+
+class RequestsEvilDomainRule(Rule):
+    rule_name = 'requests_evil_domain'
+
+    def evaluate(self, s):
+        evil_domains = self.config.get('domain', ())
+        if len(evil_domains) == 0:
+            logger.warn("Empty evil domain list, check ruleset config.")
+            return self.result(Result.unknown, "Leere Domainliste", True)
+
+        for d in s.cuckoo_report.requested_domains:
+            if d in evil_domains:
+                return self.result(Result.bad,
+                                   "Die Datei versucht mindestens eine Domain "
+                                   "aus der Blacklist zu kontaktieren "
+                                   "(%s)" % d,
+                                   False)
+
+        return self.result(Result.unknown,
+                           "Datei scheint keine Domains aus der Blacklist "
+                           "kontaktieren zu wollen",
+                           True)
+
+
+class CuckooAnalysisFailedRule(Rule):
+    rule_name = 'cuckoo_analysis_failed'
+
+    def evaluate(self, s):
+        if s.cuckoo_report.analysis_failed:
+            return self.result(Result.bad,
+                               "Die Verhaltensanalyse durch Cuckoo hat einen "
+                               "Fehler produziert und konnte nicht erfolgreich "
+                               "abgeschlossen werden",
+                               False)
+
+        return self.result(Result.unknown,
+                           "Die Verhaltensanalyse durch Cuckoo wurde "
+                           "erfolgreich abgeschlossen",
+                           True)
+
+
+class FinalRule(Rule):
+    rule_name = 'final_rule'
+
+    def evaluate(self, s):
+        return self.result(Result.unknown,
+                           "Datei scheint keine erkennbaren Schadroutinen "
+                           "zu starten",
+                           True)

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -41,7 +41,7 @@ def known(config, s):
     if s.known_to_db:
         sample_info = s.info_from_db
         return RuleResult(position,
-                          result=sample_info.get_result(),
+                          result=sample_info.result,
                           reason=sample_info.reason,
                           further_analysis=False)
 

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -38,8 +38,8 @@ def known(config, s):
     tb = tb[-1]
     position = "%s:%s" % (tb[2], tb[1])
 
-    if s.known_to_db:
-        sample_info = s.info_from_db
+    sample_info = s.info_from_db
+    if sample_info:
         return RuleResult(position,
                           result=sample_info.result,
                           reason=sample_info.reason,

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -47,11 +47,10 @@ class SampleFactory(object):
     Contains all the global configuration data and object references each
     sample needs and thus serves as a registry of potential API breakage
     perhaps deserving looking into. """
-    def __init__(self, cuckoo, db_con, connection_map, base_dir, job_hash_regex,
+    def __init__(self, cuckoo, connection_map, base_dir, job_hash_regex,
             keep_mail_data):
         # object references for interaction
         self.cuckoo = cuckoo
-        self.db_con = db_con
         self.connection_map = connection_map
 
         # configuration
@@ -60,7 +59,7 @@ class SampleFactory(object):
         self.keep_mail_data = keep_mail_data
 
     def make_sample(self, file_path, metainfo = {}, socket = None):
-        return Sample(file_path, self.cuckoo, self.db_con, metainfo,
+        return Sample(file_path, self.cuckoo, metainfo,
                 self.connection_map, socket, self.base_dir, self.job_hash_regex,
                 self.keep_mail_data)
 
@@ -78,12 +77,11 @@ class Sample(object):
     @author: Felix Bauer
     @author: Sebastian Deiss
     """
-    def __init__(self, file_path, cuckoo = None, db_con = None, metainfo = {},
+    def __init__(self, file_path, cuckoo = None, metainfo = {},
             connection_map = None, socket = None, base_dir = None,
             job_hash_regex = None, keep_mail_data = False):
         self.__path = file_path
         self.__cuckoo = cuckoo
-        self.__db_con = db_con
         self.__wd = None
         self.__filename = os.path.basename(self.__path)
         # A symlink that points to the actual file named
@@ -286,10 +284,6 @@ class Sample(object):
                 self.set_attr('sha256sum', checksum)
                 return checksum
         return self.get_attr('sha256sum')
-
-    @property
-    def info_from_db(self):
-        return self.__db_con.sample_info_fetch(self)
 
     @property
     def file_extension(self):

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -251,7 +251,7 @@ class Sample(object):
             logger.debug("Current result: %s, Rule result: %s"
                          % (self.__result, rule_result.result))
             # check if result of this rule is worse than what we know so far
-            if rule_result.result > self.__result:
+            if rule_result.result >= self.__result:
                 self.__result = rule_result.result
                 self.set_attr('reason', rule_result.reason)
 

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -300,12 +300,6 @@ class Sample(object):
     # a sample is known, its previous classification (result, reason) without
     # updating its internal state (attribute)? Why is the sample interacting
     # with the database in the first place?
-    def mark_as_in_flight(self):
-        return self.__db_con.mark_sample_in_flight(self)
-
-    def clear_in_flight(self):
-        return self.__db_con.clear_sample_in_flight(self)
-
     @property
     def known_to_db(self):
         return self.__db_con.known(self)

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -228,13 +228,7 @@ class Sample(object):
         logger.debug("Job hash for this sample: %s" % job_hash)
         return job_hash
 
-    def save_result(self):
-        if self.known_to_db:
-            logger.debug('Known sample info not logged to database')
-        else:
-            logger.debug('Saving results to database')
-            self.__db_con.analysis_save(self)
-
+    def remove_from_connection_map(self):
         if self.__connection_map is not None:
             # de-register ourselves from the connection map
             if self.__socket is not None:

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -288,21 +288,6 @@ class Sample(object):
         return self.get_attr('sha256sum')
 
     @property
-    def known(self):
-        if self.known_to_db:
-            self.set_attr('known', True)
-            return True
-        return False
-
-    # These hint at architectural breakage: Why do we sometimes want to know if
-    # a sample is known, its previous classification (result, reason) without
-    # updating its internal state (attribute)? Why is the sample interacting
-    # with the database in the first place?
-    @property
-    def known_to_db(self):
-        return self.__db_con.known(self)
-
-    @property
     def info_from_db(self):
         return self.__db_con.sample_info_fetch(self)
 
@@ -469,10 +454,9 @@ class Sample(object):
         if self.has_attr('job_id'):
             job_id = self.get_attr('job_id')
 
-        return ("<Sample(filename='%s', known='%s', job_id='%d',"
+        return ("<Sample(filename='%s', job_id='%d',"
                 " result='%s', sha256sum='%s')>"
                 % (self.__filename,
-                   'yes' if self.known else 'no',
                    job_id,
                    self.__result,
                    self.sha256sum))

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -90,6 +90,7 @@ class Sample(object):
         # sha256sum.suffix
         self.__submit_path = None
         self.__result = ruleset.Result.unchecked
+        self.__reason = None
         self.__report = []  # Peekaboo's own report
         self.__connection_map = connection_map
         self.__socket = socket
@@ -212,6 +213,9 @@ class Sample(object):
     def get_result(self):
         return self.__result
 
+    def get_reason(self):
+        return self.__reason
+
     def get_peekaboo_report(self):
         return ''.join(self.__report)
 
@@ -253,7 +257,7 @@ class Sample(object):
             # check if result of this rule is worse than what we know so far
             if rule_result.result >= self.__result:
                 self.__result = rule_result.result
-                self.set_attr('reason', rule_result.reason)
+                self.__reason = rule_result.reason
 
     def report(self):
         """
@@ -378,20 +382,6 @@ class Sample(object):
         if self.has_attr('job_id'):
             return self.get_attr('job_id')
         return -1
-
-    @property
-    def reason(self):
-        # TODO: Cover all possible cases.
-        # if reason exists and sample is not known?
-        if not self.has_attr('reason'):
-            if not self.has_attr('known'):
-                rr = self.__db_con.fetch_rule_result(self)
-                self.__result = rr.result
-                self.set_attr('known', True)
-                self.set_attr('reason',
-                              'Ausschlaggebendes Ergebnis laut Datenbank: %s'
-                              % rr.reason)
-        return self.get_attr('reason')
 
     @property
     def office_macros(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sqlalchemy>=1.0.8
+sqlalchemy>=1.1.0
 Twisted>=17.1.0
 service_identity>=16.0.0
 python-magic>=0.4.12

--- a/test.py
+++ b/test.py
@@ -66,7 +66,6 @@ class TestDatabase(unittest.TestCase):
         cls.db_con = PeekabooDatabase('sqlite:///' + cls.test_db,
                 instance_id=0, stale_in_flight_threshold=10)
         cls.factory = SampleFactory(cuckoo = None,
-                db_con = cls.db_con,
                 connection_map = None,
                 base_dir = cls.conf.sample_base_dir,
                 job_hash_regex = cls.conf.job_hash_regex,
@@ -196,7 +195,6 @@ class TestSample(unittest.TestCase):
         cls.conf = PeekabooDummyConfig()
         cls.db_con = PeekabooDatabase('sqlite:///' + cls.test_db)
         cls.factory = SampleFactory(cuckoo = None,
-                db_con = cls.db_con,
                 connection_map = None,
                 base_dir = cls.conf.sample_base_dir,
                 job_hash_regex = cls.conf.job_hash_regex,
@@ -264,7 +262,6 @@ class TestRules(unittest.TestCase):
     def setUpClass(cls):
         cls.conf = PeekabooDummyConfig()
         cls.factory = SampleFactory(cuckoo = None,
-                db_con = None,
                 connection_map = None,
                 base_dir = cls.conf.sample_base_dir,
                 job_hash_regex = cls.conf.job_hash_regex,

--- a/test.py
+++ b/test.py
@@ -37,7 +37,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from peekaboo.sample import SampleFactory
 from peekaboo.ruleset import RuleResult, Result
-from peekaboo.ruleset.rules import file_type_on_whitelist, file_type_on_greylist
+from peekaboo.ruleset.rules import FileTypeOnWhitelistRule, FileTypeOnGreylistRule
 from peekaboo.db import PeekabooDatabase, PeekabooDatabaseError
 
 class PeekabooDummyConfig(object):
@@ -280,9 +280,10 @@ class TestRules(unittest.TestCase):
             [True, ['', 'asdfjkl', '93219843298']],
             [True, []],
         ]
+        rule = FileTypeOnWhitelistRule(self.conf)
         for expected, types in combinations:
             self.sample.set_attr('mimetypes', set(types))
-            r = file_type_on_whitelist(self.conf, self.sample)
+            r = rule.evaluate(self.sample)
             self.assertEqual(r.further_analysis, expected)
 
     def test_rule_file_type_on_greylist(self):
@@ -294,9 +295,10 @@ class TestRules(unittest.TestCase):
             [False, ['', 'asdfjkl', '93219843298']],
             [True, []],
         ]
+        rule = FileTypeOnGreylistRule(self.conf)
         for expected, types in combinations:
             self.sample.set_attr('mimetypes', set(types))
-            r = file_type_on_greylist(self.conf, self.sample)
+            r = rule.evaluate(self.sample)
             self.assertEqual(r.further_analysis, expected)
 
     @classmethod

--- a/test.py
+++ b/test.py
@@ -86,14 +86,10 @@ class TestDatabase(unittest.TestCase):
         sample_info = self.db_con.sample_info_fetch(self.sample)
         self.assertEqual(self.sample.sha256sum, sample_info.sha256sum)
 
-    def test_3_fetch_rule_result(self):
-        rule_result = self.db_con.fetch_rule_result(self.sample)
-        # RuleResults from the DB have 'db' as rule name
-        self.assertEqual(rule_result.rule, 'db')
-        self.assertEqual(rule_result.result, Result.checked)
-        self.assertEqual(rule_result.reason, 'This is just a test case.')
-        # We assert True since the DB rule result always sets further_analysis to True
-        self.assertTrue(rule_result.further_analysis)
+    def test_3_fetch_result(self):
+        sample_info = self.db_con.sample_info_fetch(self.sample)
+        self.assertEqual(sample_info.result, Result.checked)
+        self.assertEqual(sample_info.reason, 'This is just a test case.')
 
     def test_4_known(self):
         self.assertTrue(self.db_con.known(self.sample))
@@ -233,8 +229,7 @@ class TestSample(unittest.TestCase):
         self.assertIsNotNone(self.sample.sha256sum)
         self.assertEqual(self.sample.job_id, -1)
         self.assertEqual(self.sample.get_result(), Result.unchecked)
-        self.assertEqual(self.sample.reason,
-                         'Ausschlaggebendes Ergebnis laut Datenbank: Datei ist dem System noch nicht bekannt')
+        self.assertEqual(self.sample.get_reason(), None)
         self.assertFalse(self.sample.office_macros)
         self.assertFalse(self.sample.known)
 

--- a/test.py
+++ b/test.py
@@ -53,32 +53,6 @@ class PeekabooDummyConfig(object):
         return config[option]
 
 
-class PeekabooDummyDB(object):
-    def sample_info2db(self, sample):
-        pass
-
-    def sample_info_fetch(self, sha256):
-        pass
-
-    def fetch_rule_result(self, sha256):
-        return RuleResult('fake_db',
-                          result=Result.checked,
-                          reason='Test Case',
-                          further_analysis=True)
-
-    def sample_info_update(self, sample):
-        pass
-
-    def known(self, sha256):
-        return False
-
-    def in_progress(self, sha256):
-        return True
-
-    def _clear_in_progress(self):
-        pass
-
-
 class TestDatabase(unittest.TestCase):
     """
     Unittests for Peekaboo's database module.

--- a/test.py
+++ b/test.py
@@ -91,9 +91,6 @@ class TestDatabase(unittest.TestCase):
         self.assertEqual(sample_info.result, Result.checked)
         self.assertEqual(sample_info.reason, 'This is just a test case.')
 
-    def test_4_known(self):
-        self.assertTrue(self.db_con.known(self.sample))
-
     def test_5_in_flight_no_cluster(self):
         # should all behave as no-ops
         self.assertTrue(self.db_con.mark_sample_in_flight(self.sample, 0))
@@ -231,7 +228,6 @@ class TestSample(unittest.TestCase):
         self.assertEqual(self.sample.get_result(), Result.unchecked)
         self.assertEqual(self.sample.get_reason(), None)
         self.assertFalse(self.sample.office_macros)
-        self.assertFalse(self.sample.known)
 
     def test_sample_attributes_with_meta_info(self):
         sample = self.factory.make_sample('test.pyc', {


### PR DESCRIPTION
Implement actual concurrency on the database, enabling multiple instances of Peekaboo to coordinate their actions. This is primarily based on a new table recording samples which are currently in flight on a instance, allowing other instances to detect this fact and hold identical samples until their analysis has been completed on the first instance.

As a followup, clean up the database module and surrounding users like Sample and the ruleset.