### PR TITLE
Trim in-source authorship info in favour of VCS metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 We use [SemVer](http://semver.org/) for versioning. For the versions available,
 see the [tags on this repository](https://github.com/scVENUS/PeekabooAV/releases).
 
-## Authors ##
+## Past and present Developers and Contributors ##
 
 * **Felix Bauer** - *Security Analyst and Project Leader* - [@Jack28](https://github.com/Jack28)
-* **Sebastian Deiss** - *Technical Lead* - [@SebastianDeiss](https://github.com/SebastianDeiss)
+* **Michael Weiser** - *Developer* - [@michaelweiser](https://github.com/michaelweiser)
+* **Sebastian Deiss** - *Former Technical Lead* - [@SebastianDeiss](https://github.com/SebastianDeiss)
 
 ## License ##
 

--- a/bin/scan_file.py
+++ b/bin/scan_file.py
@@ -25,12 +25,6 @@
 #                                                                             #
 ###############################################################################
 
-"""
-@author:     Felix Bauer, Sebastian Deiss
-@copyright:  2016-2019 science + computing ag. All rights reserved.
-@license:    GPLv3
-"""
-
 
 from __future__ import print_function
 from os import path, linesep

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,11 +15,16 @@ Status: **DRAFT**.
 * PeekabooAV is written in Python, multi-threaded, scalable, has a very powerful ruleset, and is easy to extend and personalize
 * It is able to detect: malware by its behavior, exploitation of zero days, and targeted attacks
 
-**The main developers are:**
+**Current active developers:**
 
 * Felix Bauer
 * Michael Weiser
 * Christoph Herrmann
+
+**Past developers and contributors:**
+
+* Sebastian Deiß
+* Mark Pröhl
 
 For news and announcements follow us on twitter [@peekabooAV](https://twitter.com/peekabooav).
 

--- a/peekaboo/__init__.py
+++ b/peekaboo/__init__.py
@@ -26,10 +26,9 @@
 
 
 VERSION = (1, 6, 2)
-AUTHORS = ['Felix Bauer', 'Sebastian Deiss']
 
 __version__ = '.'.join(map(str, VERSION))
-__author__ = ', '.join(AUTHORS)
+__author__ = 'Felix Bauer'
 __description__ = 'Peekaboo Extended Email Attachment Behavior Observation Owl'
 __copyright__ = 'Copyright (C) 2016-2019 science + computing ag. All rights reserved.'
 __license__ = 'GPLv3'

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -57,11 +57,7 @@ class PeekabooConfigParser( # pylint: disable=too-many-ancestors
 
 
 class PeekabooConfig(object): # pylint: disable=too-many-instance-attributes
-    """
-    This class represents the Peekaboo configuration.
-
-    @author: Sebastian Deiss
-    """
+    """ This class represents the Peekaboo configuration. """
     def __init__(self, config_file=None, log_level=None):
         """ Initialise the configuration with defaults, overwrite with command
         line options and finally read the configuration file. """
@@ -259,7 +255,6 @@ class PeekabooRulesetConfig(object):
     The ruleset configuration is stored as a dictionary in the form of
     ruleset_config[rule_name][config_option] = value | [value1, value2, ...]
 
-    @author: Sebastian Deiss
     @since: 1.6
     """
     def __init__(self, config_file):

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -51,11 +51,7 @@ logger = logging.getLogger(__name__)
 
 
 class SignalHandler():
-    """
-    Signal handler.
-
-    @author: Felix Bauer
-    """
+    """ Signal handler. """
     def __init__(self):
         """ register custom signal handler """
         self.listeners = []

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -49,11 +49,7 @@ Base = declarative_base()
 
 
 class PeekabooMetadata(Base):
-    """
-    Definition of the _meta table for Peekaboo.
-
-    @author: Sebastian Deiss
-    """
+    """ Definition of the _meta table for Peekaboo. """
     __tablename__ = '_meta'
     peekaboo_version = Column(String(10), nullable=False,
                               primary_key=True)
@@ -88,11 +84,7 @@ class InFlightSample(Base):
 
 
 class SampleInfo(Base):
-    """
-    Definition of the sample_info table.
-
-    @author: Sebastian Deiss
-    """
+    """ Definition of the sample_info table. """
     __tablename__ = 'sample_info_v%d' % DB_SCHEMA_VERSION
 
     id = Column(Integer, primary_key=True)
@@ -112,11 +104,7 @@ class SampleInfo(Base):
 
 
 class AnalysisJournal(Base):
-    """
-    Definition of the analysis_jobs table.
-
-    @author: Sebastian Deiss
-    """
+    """ Definition of the analysis_jobs table. """
     __tablename__ = 'analysis_jobs_v%d' % DB_SCHEMA_VERSION
 
     id = Column(Integer, primary_key=True)
@@ -147,11 +135,7 @@ class AnalysisJournal(Base):
 
 
 class PeekabooDatabase(object):
-    """
-    Peekaboo's database.
-
-    @author: Sebastian Deiss
-    """
+    """ Peekaboo's database. """
     def __init__(self, db_url, instance_id=0,
                  stale_in_flight_threshold=1*60*60):
         """

--- a/peekaboo/queuing.py
+++ b/peekaboo/queuing.py
@@ -37,11 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class JobQueue:
-    """
-    Peekaboo's queuing system.
-
-    @author: Sebastian Deiss
-    """
+    """ Peekaboo's queuing system. """
     def __init__(self, ruleset_config, db_con, worker_count=4,
                  queue_timeout=300, shutdown_timeout=60,
                  cluster_duplicate_check_interval=5):
@@ -338,11 +334,7 @@ class ClusterDuplicateHandler(Thread):
 
 
 class Worker(Thread):
-    """
-    A Worker thread to process a sample.
-
-    @author: Sebastian Deiss
-    """
+    """ A Worker thread to process a sample. """
     def __init__(self, wid, job_queue, ruleset_config, db_con):
         # whether we should run
         self.shutdown_requested = Event()

--- a/peekaboo/ruleset/__init__.py
+++ b/peekaboo/ruleset/__init__.py
@@ -29,9 +29,8 @@ from enum import Enum, unique
 
 @unique
 class Result(Enum):
-    """
-    @author: Felix Bauer
-    """
+    """ Enumeration of rule evaluation result severities with apropriate
+    comparison semantics. """
     unchecked = 1
     unknown = 2
     ignored = 3
@@ -51,9 +50,8 @@ class Result(Enum):
 
 
 class RuleResult:
-    """
-    @author: Felix Bauer
-    """
+    """ A rule evaluation result with severity, deciding rule, decision
+    description and reason. """
     def __init__(self, rule,
                  result=Result.unknown,
                  reason=None,

--- a/peekaboo/ruleset/engine.py
+++ b/peekaboo/ruleset/engine.py
@@ -38,7 +38,6 @@ class RulesetEngine(object):
     """
     Peekaboo's ruleset engine.
 
-    @author: Sebastian Deiss
     @since: 1.6
     """
     rules = [

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -78,9 +78,6 @@ class Sample(object):
     such as the file checksum.
 
     The data structure works together with Cuckoo to run behavioral analysis.
-
-    @author: Felix Bauer
-    @author: Sebastian Deiss
     """
     def __init__(self, file_path, cuckoo=None, status_change=None,
                  metainfo=None, base_dir=None, job_hash_regex=None,

--- a/peekaboo/server.py
+++ b/peekaboo/server.py
@@ -40,11 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 class PeekabooStreamServer(socketserver.ThreadingUnixStreamServer):
-    """
-    Asynchronous server.
-
-    @author: Sebastian Deiss
-    """
+    """ Asynchronous server. """
     def __init__(self, server_address, request_handler_cls, job_queue,
                  sample_factory, bind_and_activate=True,
                  request_queue_size=10, status_change_timeout=60):
@@ -120,11 +116,8 @@ class PeekabooStreamServer(socketserver.ThreadingUnixStreamServer):
 
 
 class PeekabooStreamRequestHandler(socketserver.StreamRequestHandler):
-    """
-    Request handler used by PeekabooStreamServer to handle analysis requests.
-
-    @author: Sebastian Deiss
-    """
+    """ Request handler used by PeekabooStreamServer to handle analysis
+    requests. """
     def setup(self):
         socketserver.StreamRequestHandler.setup(self)
         self.job_queue = self.server.job_queue

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 class Cuckoo:
-    """ Parent class, defines interface to Cuckoo """
+    """ Parent class, defines interface to Cuckoo. """
     def __init__(self, job_queue):
         self.job_queue = job_queue
         self.shutdown_requested = False
@@ -83,11 +83,7 @@ class Cuckoo:
         raise NotImplementedError
 
 class CuckooEmbed(Cuckoo):
-    """ Runs and interfaces with Cuckoo in IPC
-        
-    @author: Sebastian Deiss
-    @author: Felix Bauer
-    """
+    """ Runs and interfaces with Cuckoo in IPC. """
     def __init__(self, job_queue, cuckoo_exec, cuckoo_submit,
                  cuckoo_storage, interpreter=None):
         Cuckoo.__init__(self, job_queue)
@@ -214,11 +210,7 @@ class CuckooEmbed(Cuckoo):
         pass
 
 class CuckooApi(Cuckoo):
-    """
-    Interfaces with a Cuckoo installation via its REST API
-        
-    @author: Felix Bauer
-    """
+    """ Interfaces with a Cuckoo installation via its REST API. """
     def __init__(self, job_queue, url="http://localhost:8090", poll_interval=5):
         Cuckoo.__init__(self, job_queue)
         self.url = url
@@ -312,17 +304,12 @@ class CuckooApi(Cuckoo):
         return 0
 
 class CuckooServer(protocol.ProcessProtocol):
-    """
-    Class that is used by twisted.internet.reactor to process Cuckoo
-    output and process its behavior. Usage::
+    """ Class that is used by twisted.internet.reactor to process Cuckoo output
+    and process its behavior. Usage::
 
         srv = CuckooServer()
         reactor.spawnProcess(srv, 'python2', ['python2', '/path/to/cukoo.py'])
-        reactor.run()
-
-    @author: Felix Bauer
-    @author: Sebastian Deiss
-    """
+        reactor.run() """
     def __init__(self, cuckoo):
         self.cuckoo = cuckoo
         self.encoding = locale.getpreferredencoding()
@@ -394,12 +381,7 @@ class CuckooServer(protocol.ProcessProtocol):
 
 
 class CuckooReport(object):
-    """
-    Represents a Cuckoo analysis JSON report.
-
-    @author: Sebastian Deiss
-    @author: Felix Bauer
-    """
+    """ Represents a Cuckoo analysis JSON report. """
     def __init__(self, report):
         """
         @param report: hash with report data from Cuckoo

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     author=__author__,
     install_requires=install_requires,
     dependency_links=dependency_links,
-    author_email='felix.bauer@atos.net, sebastian.deiss@atos.net',
+    author_email='felix.bauer@atos.net',
     entry_points={
         'console_scripts': [
             'peekaboo = peekaboo.daemon:run',

--- a/test.py
+++ b/test.py
@@ -352,11 +352,7 @@ class CreatingSampleFactory(SampleFactory):
 
 
 class TestDatabase(unittest.TestCase):
-    """
-    Unittests for Peekaboo's database module.
-
-    @author: Sebastian Deiss
-    """
+    """ Unittests for Peekaboo's database module. """
     @classmethod
     def setUpClass(cls):
         """ Set up common test case resources. """
@@ -501,11 +497,7 @@ class TestDatabase(unittest.TestCase):
 
 
 class TestSample(unittest.TestCase):
-    """
-    Unittests for Samples.
-
-    @author: Sebastian Deiss
-    """
+    """ Unittests for Samples. """
     @classmethod
     def setUpClass(cls):
         """ Set up common test case resources. """
@@ -652,11 +644,7 @@ class CuckooReportSample(object):  # pylint: disable=too-few-public-methods
 
 
 class TestRules(unittest.TestCase):
-    """
-    Unittests for Rules.
-
-    @author: Felix Bauer
-    """
+    """ Unittests for Rules. """
     def test_rule_file_type_on_whitelist(self):
         """ Test whitelist rule. """
         combinations = [


### PR DESCRIPTION
Instead of maintaining ever-growing lists of authors in comments and
constants in-source, name a main author where necessary and prudent and
rely on VCS metadata instead.

Closes #64 (again and terminally)

Okay-ed out-of-band by the assassinees @Jack28 and @SebastianDeiss.