### PR TITLE
Augment distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ See documentation for details.
 
 ## devel
 
+- Distribute and install sample configuration files in/from PyPI source
+  distribution
 - Make list of rules to run configurable in members and order. See
   `ruleset.conf.sample` section `[rules]` for details.
 - Lower default for in-flight lock staleness to 15 minutes.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include README.md
 include LICENSE.txt
+include CHANGELOG.md
 include requirements.txt
 include peekaboo.conf.sample
+include ruleset.conf.sample
 include systemd/peekaboo.service
 graft peekaboo/locale

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -50,7 +50,9 @@ named ``/opt/peekaboo/etc/peekaboo.conf``. For details, please run
     $ /opt/peekaboo/bin/peekaboo --help
 
 You can configure Peekaboo according to the sample configuration in
-``peekaboo.conf.sample`` and save it to ``/opt/peekaboo/etc/peekaboo.conf``.
+``/opt/peekaboo/share/doc/peekaboo/peekaboo.conf.sample`` and save it
+to ``/opt/peekaboo/etc/peekaboo.conf``.
+The same directory also contains a sample ``ruleset.conf``.
 
 
 Database Configuration

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -118,3 +118,35 @@ Please do not forget to turn warnings back on and please do not pollute the
 code with loads of these overrides.
 
 .. _git-lint: https://pypi.org/project/git-lint/
+
+Testing PyPI Interaction
+========================
+
+We test PyPI interaction for unreleased versions, e.g. when testing the
+installer, using `devpi`_.
+
+Quick start: Install devpi, start server, configure devpi client, create user,
+log in, create overlay, configure client to use overlay by default, create
+source distribution, upload and test installation using pip:
+
+.. code-block:: shell
+
+    $ /path/to/your/venv/bin/pip install -U devpi-web devpi-client
+    $ /path/to/your/venv/bin/devpi-server --start --init
+    $ /path/to/your/venv/bin/devpi use http://localhost:3141
+    $ /path/to/your/venv/bin/devpi user -c testuser password=123
+    $ /path/to/your/venv/bin/devpi login testuser --password=123
+    $ /path/to/your/venv/bin/devpi index -c dev bases=root/pypi
+    $ /path/to/your/venv/bin/devpi use testuser/dev
+    $ cd PeekabooAV
+    $ ./setup.py sdist
+    $ /path/to/your/venv/bin/devpi upload
+    $ t=$(mktemp -d)
+    $ virtualenv --python=python3 "$t"
+    $ PIP_INDEX_URL=http://localhost:3141/testuser/dev/+simple/ "$t"/bin/pip install peekabooav
+    $ rm -rf "$t"
+
+Overriding the index to use for testing using ``PIP_INDEX_URL`` can also be
+used with other tools such as Ansible or the Peekaboo Installer.
+
+.. _devpi: https://pypi.org/project/devpi/

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@
 ###############################################################################
 
 
-from setuptools import setup, find_packages
 from codecs import open
-from os import path, system
+from os import path
 from sys import path as pythonpath
+from setuptools import setup, find_packages
 
 # Add peekaboo to PYTHONPATH
 pythonpath.append(path.dirname(path.dirname(path.abspath(__file__))))
@@ -70,6 +70,48 @@ setup(
     keywords='Cuckoo, Amavis',
     packages=find_packages(exclude=['docs', 'tests*']),
     include_package_data=True,
+    # package_files augments MANIFEST.in in what is packaged into a
+    # distribution. Files to add must be inside a package. Thus files in the
+    # root of our source directory cannot be packaged with this. Files inside
+    # packages will stay there, totally obscured to the user. Meant for default
+    # configuration or other package-internal data.
+    #  package_files=[...],
+    #
+    # data_files is another way to augment what is installed from the
+    # distribution. Allows paths outside packages for both sources and targets.
+    # Absolute paths are strongly discouraged because they exhibit confusing if
+    # not downright broken behaviour. Relative paths are added to the
+    # distribution and then installed into
+    # site-packages/<package>-<ver>.egg/<relative path> (setup.py) or <python
+    # prefix>/<relative path> (pip). The latter works well with venvs and
+    # distribution-provided pip (e.g. /usr/local/<relative path>).
+    # We go this route for providing sample files because using setup.py
+    # directly is discouraged anyway and "only" tucks the files away in the egg
+    # directory, providing the most consistent option.
+    data_files=[
+        ("share/doc/peekaboo", [
+            "README.md",
+            "CHANGELOG.md",
+            "peekaboo.conf.sample",
+            "ruleset.conf.sample",
+        ]),
+        ("share/doc/peekaboo/systemd", [
+            "systemd/peekaboo.service",
+        ]),
+        ("share/doc/peekaboo/amavis", [
+            "amavis/10-ask_peekaboo",
+        ]),
+    ],
+    # overriding the whole install_data command allows for arbitrary
+    # installation mechanics but does not solve the problem of adding files to
+    # a binary distribution (e.g. wheel, which pip uses internally always) in
+    # such a way that they will later be put at the correct location. Thus they
+    # would go around pip entirely, be missing from any actual wheel
+    # distribution package, pollute the system directly and not be removed upon
+    # uninstall or upgrade.
+    #  cmdclass={
+    #      'install_data': OffsetDataInstall,
+    #  },
     author=__author__,
     install_requires=install_requires,
     dependency_links=dependency_links,

--- a/systemd/peekaboo.service
+++ b/systemd/peekaboo.service
@@ -8,7 +8,7 @@
 
 [Unit]
 Description=Peekaboo Extended Email Attachment Behavior Observation Owl
-After=network.target
+After=network.target cuckoo-api.service
 
 [Service]
 User=peekaboo


### PR DESCRIPTION
Add additional files to the source distribution and install them into `<prefix>/share/doc/peekaboo` to give the user an actual chance to install and run us from only the PyPI distribution. This is also to be used by the installer so it does not rely on having the full source directory available and config file duplication is minimized.