### PR TITLE
Add support for Cuckoo API Authentication Bearer Token

### DIFF
--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -79,6 +79,10 @@
 # api mode
 #url              :    http://127.0.0.1:8090
 #poll_interval    :    5
+# From version 2.0.7 cuckoo API has authentication support.
+# New installations create a bearer token by default and require it but upgraded
+# installations don't automatically get one.
+#api_token        :    <empty>
 
 [cluster]
 # if multiple instances are to run in parallel and avoid concurrent analysis of

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -298,6 +298,7 @@ class PeekabooConfig(PeekabooConfigParser):
         self.ruleset_config = '/opt/peekaboo/etc/ruleset.conf'
         self.cuckoo_mode = "api"
         self.cuckoo_url = 'http://127.0.0.1:8090'
+        self.cuckoo_api_token = ''
         self.cuckoo_poll_interval = 5
         self.cuckoo_storage = '/var/lib/peekaboo/.cuckoo/storage'
         self.cuckoo_exec = '/opt/cuckoo/bin/cuckoo'
@@ -330,6 +331,7 @@ class PeekabooConfig(PeekabooConfigParser):
             'ruleset_config': ['ruleset', 'config'],
             'cuckoo_mode': ['cuckoo', 'mode'],
             'cuckoo_url': ['cuckoo', 'url'],
+            'cuckoo_api_token': ['cuckoo', 'api_token'],
             'cuckoo_poll_interval': ['cuckoo', 'poll_interval'],
             'cuckoo_storage': ['cuckoo', 'storage_path'],
             'cuckoo_exec': ['cuckoo', 'exec'],

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -351,6 +351,7 @@ def run():
     # otherwise it's the new API method and default
     else:
         cuckoo = CuckooApi(job_queue, config.cuckoo_url,
+                           config.cuckoo_api_token,
                            config.cuckoo_poll_interval)
 
     sig_handler = SignalHandler()


### PR DESCRIPTION
Since version 2.0.7 the Cuckoo API requires authentication via a bearer auth token set in the cuckoo configuration and passed to the API with every request in the HTTP header