### PR TITLE
Ignore gpg signatures

### DIFF
--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -86,6 +86,10 @@ expression.2  : sample.meta_info_name_declared == 'smime.p7s'
                         'application/pkcs7-mime',
                         'application/x-pkcs7-mime'
                     } -> ignore
+expression.3  : sample.meta_info_name_declared == 'signature.asc'
+                    and sample.meta_info_type_declared in {
+                        'application/pgp-signature'
+                    } -> ignore
 
 [cuckoo_evil_sig]
 signature.1  : A potential heapspray has been detected. .*


### PR DESCRIPTION
New rule to ignore gpg sinatures (Closes #40)

Includes test case