### PR TITLE
Handles deprecation warnings in unit tests with python3

### DIFF
--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -515,7 +515,7 @@ class ExpressionRule(Rule):
                     if result is None:
                         break
                 except IdentifierMissingException as error:
-                    if error.message == "cuckooreport":
+                    if "cuckooreport" == error.args[0]:
                         context['variables']['cuckooreport'] = self.get_cuckoo_report(sample)
                     # here elif for other reports
                     else:


### PR DESCRIPTION
DeprecationWarning: Please use assertRaisesRegex instead is due to
a change in python from 3.2 where funcitons have been renamed. 
This pull request introdues a change in handling python2 and python3
differently for those functions.