### PR TITLE
Added number of rule to report that classified the sample

### DIFF
--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -542,8 +542,8 @@ class ExpressionRule(Rule):
 
             if result:
                 return self.result(result,
-                                   _("A rule classified the sample as %s")
-                                   % result,
+                                   _("The rule (%d) classified the sample as %s")
+                                   % (i, result),
                                    False)
 
         return self.result(Result.unknown,


### PR DESCRIPTION
The peekaboo report didn't contain any clue about which generic rule expression
classified the sample.

Now the number of the rule is put into the report (count from first rule).

Closes #102