### PR TITLE
Adds ignore to smime rule for p7m and p7c

### DIFF
--- a/peekaboo/ruleset/expressions.py
+++ b/peekaboo/ruleset/expressions.py
@@ -145,6 +145,9 @@ class OperatorRegex(object):
                     return True
             return False
 
+        if other is None:
+            return False
+
         return function(other)
 
     def __eq__(self, other):

--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -79,7 +79,7 @@ keyword.2 : AutoClose
 
 [expressions]
 expression.1  : sample.mimetypes <= {'text/plain', 'inode/x-empty'} -> ignore
-expression.2  : sample.meta_info_name_declared == 'smime.p7s'
+expression.2  : sample.meta_info_name_declared == /smime.p7[mcs]/
                     and sample.meta_info_type_declared in {
                         'application/pkcs7-signature',
                         'application/x-pkcs7-signature',

--- a/tests/test.py
+++ b/tests/test.py
@@ -868,7 +868,9 @@ unknown : baz'''
             expression.2  : sample.meta_info_name_declared == 'signature.asc'
                 and sample.meta_info_type_declared in {
                     'application/pgp-signature'
-                } -> ignore'''
+                } -> ignore
+            '''
+        rule = ExpressionRule(CreatingConfigParser(config))
 
         part = {"full_name": "p001",
                 "name_declared": "smime.p7s",
@@ -879,34 +881,32 @@ unknown : baz'''
             cuckoo=None, base_dir=None, job_hash_regex=None,
             keep_mail_data=False, processing_info_dir=None)
 
+        sample = factory.make_sample('file.1')
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.unknown)
+
         # test smime signatures
         sample = factory.make_sample('', metainfo=part)
-        rule = ExpressionRule(CreatingConfigParser(config))
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.ignored)
 
         sample.meta_info_name_declared = "asmime.p7m"
-        rule = ExpressionRule(CreatingConfigParser(config))
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 
         sample.meta_info_name_declared = "smime.p7m"
-        rule = ExpressionRule(CreatingConfigParser(config))
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.ignored)
 
         sample.meta_info_name_declared = "smime.p7o"
-        rule = ExpressionRule(CreatingConfigParser(config))
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 
         sample.meta_info_name_declared = "smime.p7"
-        rule = ExpressionRule(CreatingConfigParser(config))
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 
         sample.meta_info_name_declared = "file"
-        rule = ExpressionRule(CreatingConfigParser(config))
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -858,7 +858,7 @@ unknown : baz'''
     def test_rule_ignore_mail_signatures(self):
         """ Test rule to ignore cryptographic mail signatures. """
         config = '''[expressions]
-            expression.1  : sample.meta_info_name_declared == 'smime.p7s'
+            expression.1  : sample.meta_info_name_declared == /smime.p7[mcs]/
                 and sample.meta_info_type_declared in {
                     'application/pkcs7-signature',
                     'application/x-pkcs7-signature',
@@ -884,6 +884,26 @@ unknown : baz'''
         rule = ExpressionRule(CreatingConfigParser(config))
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.ignored)
+
+        sample.meta_info_name_declared = "asmime.p7m"
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.unknown)
+
+        sample.meta_info_name_declared = "smime.p7m"
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.ignored)
+
+        sample.meta_info_name_declared = "smime.p7o"
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.unknown)
+
+        sample.meta_info_name_declared = "smime.p7"
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.unknown)
 
         sample.meta_info_name_declared = "file"
         rule = ExpressionRule(CreatingConfigParser(config))


### PR DESCRIPTION
Now also signed and encrypted messages (smime.p7m) and certificates (smime.p7c)
are ignored.

Before only signatures (smime.p7s) were ignored.

Closes #39