### PR TITLE
Introduce FiletoolsReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ See documentation for details.
 ## devel
 
 - Generic rules allow to evaluate expressions with sample, cuckooreport and
-  olereport
+  olereport and filereport
 - Distribute and install sample configuration files in/from PyPI source
   distribution
 - Make list of rules to run configurable in members and order. See

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -63,6 +63,10 @@ Rules can then be constructed like:
     expression.4  : /suspicious/ in olereport.vba_code -> bad
     expression.5  : olereport.has_office_macros == True
                         and cuckooreport.score > 4 -> bad
+    expression.6  : sample.file_extension in {"doc", "docx"}
+                        and /.*\/rtf/ in sample.mimetypes -> bad
+    expression.7  : sample.file_extension in {"doc", "docx"}
+                        and not filereport.type_by_content in { /application\/.*word/ } -> bad
 
 Attributes of sample
 --------------------
@@ -97,3 +101,11 @@ Attributes of olereport
 
     has_office_macro
     vba_code
+
+Attribuges of filereport
+------------------------
+
+.. code-block:: shell
+
+    type_by_content
+    type_by_name

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -34,6 +34,7 @@ from peekaboo.ruleset.expressions import ExpressionParser, \
 from peekaboo.exceptions import PeekabooAnalysisDeferred, \
         CuckooSubmitFailedException, PeekabooRulesetConfigError
 from peekaboo.toolbox.ole import Oletools, OletoolsReport
+from peekaboo.toolbox.files import Filetools, FiletoolsReport
 
 
 logger = logging.getLogger(__name__)
@@ -139,6 +140,19 @@ class Rule(object):
 
         oletool = Oletools()
         report = OletoolsReport(oletool.get_report(sample))
+        return report
+
+    def get_filetools_report(self, sample):
+        """ Get the samples filetools_report or generate it.
+
+            @returns: FiletoolsReport
+        """
+        report = sample.filetools_report
+        if report is not None:
+            return report
+
+        filetools = Filetools()
+        report = FiletoolsReport(filetools.get_report(sample))
         return report
 
 
@@ -531,6 +545,8 @@ class ExpressionRule(Rule):
                                 Result.failed,
                                 _("Evaluation of expression couldn't get cuckoo report."),
                                 False)
+                    elif error.args[0] == "filereport":
+                        context['variables']['filereport'] = self.get_filetools_report(sample)
                     elif error.args[0] == "olereport":
                         context['variables']['olereport'] = self.get_oletools_report(sample)
                     # here elif for other reports

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -91,6 +91,7 @@ class Sample(object):
         self.__cuckoo_job_id = -1
         self.__cuckoo_report = None
         self.__oletools_report = None
+        self.__filetools_report = None
         self.__done = False
         self.__status_change = status_change
         self.__result = Result.unchecked
@@ -462,6 +463,11 @@ class Sample(object):
         return self.__oletools_report
 
     @property
+    def filetools_report(self):
+        """ Returns the filetools report """
+        return self.__filetools_report
+
+    @property
     def submit_path(self):
         """ Returns the path to use for submission to Cuckoo """
         return self.__submit_path
@@ -486,6 +492,10 @@ class Sample(object):
     def register_oletools_report(self, report):
         """ Records a Oletools report for alter evaluation. """
         self.__oletools_report = report
+
+    def register_filetools_report(self, report):
+        """ Records a Filetools report for alter evaluation. """
+        self.__filetools_report = report
 
     def cleanup(self):
         """ Clean up after the sample has been analysed, removing a potentially

--- a/peekaboo/toolbox/files.py
+++ b/peekaboo/toolbox/files.py
@@ -25,9 +25,8 @@
 
 
 import logging
-import subprocess
-import magic
 import mimetypes
+import magic
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +40,6 @@ def guess_mime_type_from_file_contents(file_path):
 
     return mt
 
-
 def guess_mime_type_from_filename(file_path):
     """ Guess the type of a file based on its filename or URL. """
     if not mimetypes.inited:
@@ -53,3 +51,49 @@ def guess_mime_type_from_filename(file_path):
         return None
 
     return mt
+
+
+class Filetools(object):
+    """ Parent class, defines interface to various file tools. """
+    def get_report(self, sample):
+        """ Return filetools report or create if not already cached. """
+        if sample.filetools_report != None:
+            return sample.filetools_report
+
+        report = {}
+
+        report["type_by_content"] = guess_mime_type_from_file_contents(sample.file_path)
+        report["type_by_name"] = guess_mime_type_from_filename(sample.filename)
+
+        sample.register_filetools_report(FiletoolsReport(report))
+        return report
+
+
+class FiletoolsReport(object):
+    """ Represents a custom Filetools report. """
+    def __init__(self, report):
+        self.report = report
+
+    def __str__(self):
+        return "<FiletoolsReport('%s'>" % self.report
+
+    @property
+    def type_by_content(self):
+        """
+        Guesses the type of a file based on the files contents.
+        """
+
+        try:
+            return self.report['type_by_content']
+        except KeyError:
+            return False
+
+    @property
+    def type_by_name(self):
+        """
+        Guesses the type of a file based on its filename.
+        """
+        try:
+            return self.report['type_by_name']
+        except KeyError:
+            return ""

--- a/tests/test.py
+++ b/tests/test.py
@@ -924,6 +924,60 @@ unknown : baz'''
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.bad)
 
+    def test_rule_expressions_rtf(self):
+        """ Test generic rule on rtf docs and types. """
+        config = '''[expressions]
+            expression.0  : sample.file_extension in {"doc", "docx"}
+                and /.*\/(rtf|richtext)/ in sample.mimetypes -> bad
+        '''
+
+        factory = SampleFactory(
+            cuckoo=None, base_dir=None, job_hash_regex=None,
+            keep_mail_data=False, processing_info_dir=None)
+        tests_data_dir = os.path.dirname(os.path.abspath(__file__))+"/test-data"
+
+        part = {"full_name": "p001",
+                "name_declared": "file1.doc",
+                "type_declared": "application/word"
+               }
+
+        sample = factory.make_sample(tests_data_dir+'/office/blank.doc', metainfo=part)
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.unknown)
+
+        sample = factory.make_sample(tests_data_dir+'/office/example.rtf', metainfo=part)
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.bad)
+
+    def test_rule_expression_filetools(self):
+        """ Test generic rule on filetoolsreport. """
+        config = '''[expressions]
+            expression.0  : sample.file_extension in {"doc", "docx"}
+                and not filereport.type_by_content in { /application\/.*word/ } -> bad
+        '''
+
+        factory = SampleFactory(
+            cuckoo=None, base_dir=None, job_hash_regex=None,
+            keep_mail_data=False, processing_info_dir=None)
+        tests_data_dir = os.path.dirname(os.path.abspath(__file__))+"/test-data"
+
+        part = {"full_name": "p001",
+                "name_declared": "file1.doc",
+                "type_declared": "application/word"
+               }
+
+        sample = factory.make_sample(tests_data_dir+'/office/blank.doc', metainfo=part)
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.unknown)
+
+        sample = factory.make_sample(tests_data_dir+'/office/example.rtf', metainfo=part)
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.bad)
+
     def test_rule_expressions_cuckooreport_context(self):
         """ Test generic rule cuckooreport context """
         config = '''[expressions]
@@ -953,7 +1007,7 @@ unknown : baz'''
     def test_rule_expressions_olereport_context(self):
         """ Test generic rule olereport context """
         config = '''[expressions]
-            expression.3  : sample.file_extension in {'doc', 'rtf'} and olereport.has_office_macros == True -> bad
+            expression.3  : sample.file_extension in {'doc', 'rtf', 'rtx'} and olereport.has_office_macros == True -> bad
         '''
 
         factory = CreatingSampleFactory(


### PR DESCRIPTION
Filetools in now an analyser that can be used to create a report on the file and its
contents.

It specifically produces a file type from either file content or file name.