### PR TITLE
Correct handling of python3 encoding and decoding in peekaboo-util

### DIFF
--- a/bin/peekaboo-util.py
+++ b/bin/peekaboo-util.py
@@ -50,14 +50,14 @@ class PeekabooUtil(object):
         """ Send request to peekaboo and return its answer """
         logger.debug('Sending request: %s', request)
 
-        self.peekaboo.send(request)
+        self.peekaboo.send(request.encode('utf-8'))
         print ('Waiting for response...')
 
         buf = ''
         while True:
             data = self.peekaboo.recv(1024)
             if data:
-                buf += data
+                buf += data.decode('utf-8')
                 if output:
                     print(data, end='')
             else:


### PR DESCRIPTION
Before entering data through the socket was not correctly decoded as well as
data sent through it.

Now utf-8 is used consistently.