### PR TITLE
oletools: Add bug workaround for macro extraction

### DIFF
--- a/peekaboo/toolbox/ole.py
+++ b/peekaboo/toolbox/ole.py
@@ -48,8 +48,19 @@ class Oletools(object):
             try:
                 report['vba'] = vbaparser.reveal()
             except TypeError:
-                # no macros
+                # office document with no macros
                 pass
+
+            all_macros = vbaparser.extract_all_macros()
+            if (report['has_macros'] and len(all_macros) == 1
+                and type(all_macros[0]) is tuple
+                and len(all_macros[0]) >= 3
+                and all_macros[0][2] == sample.file_path):
+                logger.warning("Buggy oletools version detected, result "
+                    "overridden. May lead to false negatives, please update to "
+                    "fixed version")
+                report['has_macros'] = False
+
             vbaparser.close()
         except IOError:
             raise

--- a/tests/test-data/office/file.txt
+++ b/tests/test-data/office/file.txt
@@ -1,0 +1,1 @@
+file.txt

--- a/tests/test.py
+++ b/tests/test.py
@@ -751,13 +751,15 @@ unknown : baz'''
             keyword.1 : AutoOpen
             keyword.2 : AutoClose
             keyword.3 : suSPi.ious'''
-        rule = OfficeMacroWithSuspiciousKeyword(CreatingConfigParser(config))
+
         # sampe factory to create samples
         factory = CreatingSampleFactory(
             cuckoo=None, base_dir=None, job_hash_regex=None,
             keep_mail_data=False, processing_info_dir=None)
         tests_data_dir = os.path.dirname(os.path.abspath(__file__))+"/test-data"
 
+        # test if macro with suspicious keyword
+        rule = OfficeMacroWithSuspiciousKeyword(CreatingConfigParser(config))
         combinations = [
             # no office document file extension
             [Result.unknown, factory.create_sample('test.nodoc', 'test')],
@@ -980,6 +982,16 @@ unknown : baz'''
             cuckoo=None, base_dir=None, job_hash_regex=None,
             keep_mail_data=False, processing_info_dir=None)
         tests_data_dir = os.path.dirname(os.path.abspath(__file__))+"/test-data"
+
+        sample = factory.make_sample(tests_data_dir+'/office/empty.doc')
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.unknown)
+
+        sample = factory.make_sample(tests_data_dir+'/office/file.txt')
+        rule = ExpressionRule(CreatingConfigParser(config))
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.unknown)
 
         sample = factory.make_sample(tests_data_dir+'/office/blank.doc')
         rule = ExpressionRule(CreatingConfigParser(config))


### PR DESCRIPTION
When called on an empty or text document oletools will falsely report that it
contains macros and returns a one item list of macros which contains only the
filename again.

Add a workaround to the oletools analyser to detect this behaviour, warn about
it and override the result.

Until a fixed version of oletools is available.

Extend the test suite to catch these cases.