### PR TITLE
daemon: Deprecate Cuckoo embedded mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ See documentation for details.
 
 ## devel
 
+- Embedded Cuckoo mode is deprecated now and scheduled for removal in a future
+  release. A warning is printed at startup if embed mode is in use.
 - Generic rules allow to evaluate expressions with sample, cuckooreport and
   olereport
 - Distribute and install sample configuration files in/from PyPI source

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -338,6 +338,10 @@ def run():
         cluster_duplicate_check_interval=cldup_check_interval)
 
     if config.cuckoo_mode == "embed":
+        logger.warning(
+            "Embedded mode for Cuckoo is deprecated and will be removed in "
+            "a future release. Please switch to REST API mode.")
+
         cuckoo = CuckooEmbed(job_queue, config.cuckoo_exec,
                              config.cuckoo_submit, config.cuckoo_storage,
                              config.interpreter)


### PR DESCRIPTION
Update changelog and add a warning message to startup indicating that
embed mode is now deprecated.

Closes #126.