### PR TITLE
systemd: Start after mysql or postgres

### DIFF
--- a/systemd/peekaboo.service
+++ b/systemd/peekaboo.service
@@ -8,7 +8,7 @@
 
 [Unit]
 Description=Peekaboo Extended Email Attachment Behavior Observation Owl
-After=network.target cuckoo-api.service
+After=network.target cuckoo-api.service mysql.service postgresql.service
 
 [Service]
 User=peekaboo


### PR DESCRIPTION
Similarly to the cuckoo api service we want to be started after our
database is up. Since we support mysql and postgres (and sqlite which
does not have a daemon), we add ordering for both of them. Since we
don't know which the user chooses, we're not adding a hard dependency on
either one. Instead the admin can enable the respective service or add a
Requires= directive in a local systemd drop-in config.

Possible fallout from this is that a user has mysql *and* postgres on a
peekaboo machine and for some reason wants to start the one not used by
peekaboo after peekaboo. Our ordering would break this. But this should
also be overrideable by a drop-in config.