### PR TITLE
Original filename

### DIFF
--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -82,6 +82,15 @@
 # Cuckoo's database.
 #submit_original_filename : yes
 
+# Specify how long to track running Cuckoo jobs before giving up on them. This
+# does not actively cancel jobs. It's rather meant to handle cases where jobs
+# have for some reason been dropped by or got stuck within Cuckoo. This value
+# is unrelated to how long our client is willing to wait for a result because
+# even if it gives up on us we would normally want to learn and cache the job
+# result because the analysis was expensive and the sample might be presented
+# to us again.
+#maximum_job_age : 900
+
 # From version 2.0.7 cuckoo API has authentication support.
 # New installations create a bearer token by default and require it but upgraded
 # installations don't automatically get one.

--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -76,6 +76,12 @@
 # api mode
 #url              :    http://127.0.0.1:8090
 #poll_interval    :    5
+
+# Submit samples with their original filenames if available. Enhances
+# authenticity of analysis environment but also leaks original filenames into
+# Cuckoo's database.
+#submit_original_filename : yes
+
 # From version 2.0.7 cuckoo API has authentication support.
 # New installations create a bearer token by default and require it but upgraded
 # installations don't automatically get one.

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -308,6 +308,7 @@ class PeekabooConfig(PeekabooConfigParser):
         self.cuckoo_url = 'http://127.0.0.1:8090'
         self.cuckoo_api_token = ''
         self.cuckoo_poll_interval = 5
+        self.cuckoo_submit_original_filename = True
         self.cuckoo_storage = '/var/lib/peekaboo/.cuckoo/storage'
         self.cuckoo_exec = '/opt/cuckoo/bin/cuckoo'
         self.cuckoo_submit = '/opt/cuckoo/bin/cuckoo submit'
@@ -340,6 +341,8 @@ class PeekabooConfig(PeekabooConfigParser):
             'cuckoo_url': ['cuckoo', 'url'],
             'cuckoo_api_token': ['cuckoo', 'api_token'],
             'cuckoo_poll_interval': ['cuckoo', 'poll_interval'],
+            'cuckoo_submit_original_filename': [
+                'cuckoo', 'submit_original_filename'],
             'cuckoo_storage': ['cuckoo', 'storage_path'],
             'cuckoo_exec': ['cuckoo', 'exec'],
             'cuckoo_submit': ['cuckoo', 'submit'],

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -309,6 +309,7 @@ class PeekabooConfig(PeekabooConfigParser):
         self.cuckoo_api_token = ''
         self.cuckoo_poll_interval = 5
         self.cuckoo_submit_original_filename = True
+        self.cuckoo_maximum_job_age = 15*60
         self.cuckoo_storage = '/var/lib/peekaboo/.cuckoo/storage'
         self.cuckoo_exec = '/opt/cuckoo/bin/cuckoo'
         self.cuckoo_submit = '/opt/cuckoo/bin/cuckoo submit'
@@ -343,6 +344,7 @@ class PeekabooConfig(PeekabooConfigParser):
             'cuckoo_poll_interval': ['cuckoo', 'poll_interval'],
             'cuckoo_submit_original_filename': [
                 'cuckoo', 'submit_original_filename'],
+            'cuckoo_maximum_job_age': ['cuckoo', 'maximum_job_age'],
             'cuckoo_storage': ['cuckoo', 'storage_path'],
             'cuckoo_exec': ['cuckoo', 'exec'],
             'cuckoo_submit': ['cuckoo', 'submit'],

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -354,7 +354,8 @@ def run():
     else:
         cuckoo = CuckooApi(job_queue, config.cuckoo_url,
                            config.cuckoo_api_token,
-                           config.cuckoo_poll_interval)
+                           config.cuckoo_poll_interval,
+                           config.cuckoo_submit_original_filename)
 
     sig_handler = SignalHandler()
     sig_handler.register_listener(cuckoo)

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -355,7 +355,8 @@ def run():
         cuckoo = CuckooApi(job_queue, config.cuckoo_url,
                            config.cuckoo_api_token,
                            config.cuckoo_poll_interval,
-                           config.cuckoo_submit_original_filename)
+                           config.cuckoo_submit_original_filename,
+                           config.cuckoo_maximum_job_age)
 
     sig_handler = SignalHandler()
     sig_handler.register_listener(cuckoo)

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -114,6 +114,9 @@ class Rule(object):
 
             @returns: CuckooReport
         """
+        if sample.cuckoo_failed:
+            return None
+
         report = sample.cuckoo_report
         if report is not None:
             return report

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -89,6 +89,7 @@ class Sample(object):
         # sha256sum.suffix
         self.__submit_path = None
         self.__cuckoo_job_id = -1
+        self.__cuckoo_failed = False
         self.__cuckoo_report = None
         self.__oletools_report = None
         self.__done = False
@@ -452,6 +453,11 @@ class Sample(object):
         return self.__file_stat.st_size
 
     @property
+    def cuckoo_failed(self):
+        """ Returns whether the Cuckoo analysis failed. """
+        return self.__cuckoo_failed
+
+    @property
     def cuckoo_report(self):
         """ Returns the cuckoo report """
         return self.__cuckoo_report
@@ -478,6 +484,10 @@ class Sample(object):
             _('Sample %s successfully submitted to Cuckoo as job %d')
             % (self, self.__cuckoo_job_id))
         return self.__cuckoo_job_id
+
+    def mark_cuckoo_failure(self):
+        """ Records whether Cuckoo analysis failed. """
+        self.__cuckoo_failed = True
 
     def register_cuckoo_report(self, report):
         """ Records a Cuckoo report for later evaluation. """

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -335,8 +335,11 @@ class CuckooApi(Cuckoo):
         path = sample.submit_path
         filename = os.path.basename(path)
         # override with the original file name if available
-        if self.submit_original_filename and sample.name_declared:
-            filename = sample.name_declared
+        if self.submit_original_filename:
+            if sample.name_declared:
+                filename = sample.name_declared
+            elif sample.filename:
+                filename = sample.filename
 
         files = {"file": (filename, open(path, 'rb'))}
         logger.debug("Creating Cuckoo task with content from %s and "

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -269,12 +269,14 @@ class WhitelistRetry(urllib3.util.retry.Retry):
 
 class CuckooApi(Cuckoo):
     """ Interfaces with a Cuckoo installation via its REST API. """
-    def __init__(self, job_queue, url="http://localhost:8090", api_token="", poll_interval=5,
-                 retries=5, backoff=0.5):
+    def __init__(self, job_queue, url="http://localhost:8090", api_token="",
+                 poll_interval=5, submit_original_filename=True, retries=5,
+                 backoff=0.5):
         super().__init__(job_queue)
         self.url = url
         self.api_token = api_token
         self.poll_interval = poll_interval
+        self.submit_original_filename = submit_original_filename
 
         # urrlib3 backoff formula:
         # <backoff factor> * (2 ^ (<retry count so far> - 1))
@@ -333,7 +335,7 @@ class CuckooApi(Cuckoo):
         path = sample.submit_path
         filename = os.path.basename(path)
         # override with the original file name if available
-        if sample.name_declared:
+        if self.submit_original_filename and sample.name_declared:
             filename = sample.name_declared
 
         files = {"file": (filename, open(path, 'rb'))}

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -26,6 +26,7 @@
 
 from future.builtins import super  # pylint: disable=wrong-import-order
 
+import datetime
 import re
 import os
 import locale
@@ -46,6 +47,24 @@ from peekaboo.exceptions import CuckooSubmitFailedException
 logger = logging.getLogger(__name__)
 
 
+class CuckooJob(object):
+    """ Remember sample and submission time of a Cuckoo job. """
+    def __init__(self, sample):
+        self.__sample = sample
+        self.__submission_time = datetime.datetime.utcnow()
+
+    def is_older_than(self, seconds):
+        """ Returns True if the difference between submission time and now,
+        i.e. the age of the job, is larger than given number of seconds. """
+        max_age = datetime.timedelta(seconds=seconds)
+        return datetime.datetime.utcnow() - self.__submission_time > max_age
+
+    @property
+    def sample(self):
+        """ Returns the sample the job is analyzing. """
+        return self.__sample
+
+
 class Cuckoo(object):
     """ Parent class, defines interface to Cuckoo. """
     def __init__(self, job_queue):
@@ -53,6 +72,7 @@ class Cuckoo(object):
         self.shutdown_requested = Event()
         self.shutdown_requested.clear()
         self.running_jobs = {}
+        # reentrant because we're doing nested calls within critical sections
         self.running_jobs_lock = RLock()
 
     def register_running_job(self, job_id, sample):
@@ -76,7 +96,29 @@ class Cuckoo(object):
                     'A job with ID %d is already registered as running '
                     'for sample %s' % (job_id, self.running_jobs[job_id]))
 
-            self.running_jobs[job_id] = sample
+            self.running_jobs[job_id] = CuckooJob(sample)
+
+    def deregister_running_job(self, job_id):
+        """ Deregister a running job by job id.
+
+        @returns: Sample object of the job or None if job not found. """
+        with self.running_jobs_lock:
+            job = self.running_jobs.pop(job_id, None)
+            if job is not None:
+                return job.sample
+
+        return None
+
+    def deregister_running_job_if_too_old(self, job_id, max_age):
+        """ Check if a job has gotten too old and remove it from the list of
+        running jobs if so.
+
+        @returns: Sample object of the job or None if job not found. """
+        with self.running_jobs_lock:
+            if self.running_jobs[job_id].is_older_than(max_age):
+                return self.deregister_running_job(job_id)
+
+        return None
 
     def resubmit_with_report(self, job_id):
         """ Resubmit a sample to the job queue after the report became
@@ -88,26 +130,39 @@ class Cuckoo(object):
         @returns: None """
         logger.debug("Analysis done for task #%d" % job_id)
 
-        with self.running_jobs_lock:
-            sample = self.running_jobs.pop(job_id, None)
-
+        sample = self.deregister_running_job(job_id)
         if sample is None:
             logger.debug('No sample found for job ID %d', job_id)
             return None
 
         logger.debug('Requesting Cuckoo report for sample %s', sample)
         report = self.get_report(job_id)
-
-        # do not register the report with the sample if we were unable to
-        # get it because e.g. it was corrupted or the API connection
-        # failed. This will cause the sample to be resubmitted to Cuckoo
-        # upon the next try to access the report.
-        # TODO: This can cause an endless loop.
-        if report is not None:
+        if report is None:
+            # mark analysis as failed if we could not get the report e.g.
+            # because it was corrupted or the API connection failed.
+            sample.mark_cuckoo_failure()
+        else:
             reportobj = CuckooReport(report)
             sample.register_cuckoo_report(reportobj)
 
         self.job_queue.submit(sample, self.__class__)
+        return None
+
+    def resubmit_as_failed_if_too_old(self, job_id, max_age):
+        """ Resubmit a sample to the job queue with a failure report if the
+        Cuckoo job has been running for too long.
+
+        @param job_id: ID of job to check.
+        @type job_id: int
+        @param max_age: maximum job age in seconds
+        @type max_age: int
+        """
+        sample = self.deregister_running_job_if_too_old(job_id, max_age)
+        if sample is not None:
+            logger.warning("Dropped job %d because it has been running for "
+                           "too long", job_id)
+            sample.mark_cuckoo_failure()
+            self.job_queue.submit(sample, self.__class__)
 
     def shut_down(self):
         """ Request the module to shut down. """
@@ -270,13 +325,14 @@ class WhitelistRetry(urllib3.util.retry.Retry):
 class CuckooApi(Cuckoo):
     """ Interfaces with a Cuckoo installation via its REST API. """
     def __init__(self, job_queue, url="http://localhost:8090", api_token="",
-                 poll_interval=5, submit_original_filename=True, retries=5,
-                 backoff=0.5):
+                 poll_interval=5, submit_original_filename=True,
+                 max_job_age=900, retries=5, backoff=0.5):
         super().__init__(job_queue)
         self.url = url
         self.api_token = api_token
         self.poll_interval = poll_interval
         self.submit_original_filename = submit_original_filename
+        self.max_job_age = max_job_age
 
         # urrlib3 backoff formula:
         # <backoff factor> * (2 ^ (<retry count so far> - 1))
@@ -422,6 +478,15 @@ class CuckooApi(Cuckoo):
 
                 if job["task"]["status"] == "reported":
                     self.resubmit_with_report(job_id)
+                    continue
+
+                # drop jobs which have been running for too long. This is
+                # mainly to prevent accumulation of jobs in our job list which
+                # will never finish. We still want to wait for jobs to finish
+                # even though our client might not be interested any more so
+                # that we have the result cached for the next time we get the
+                # same sample.
+                self.resubmit_as_failed_if_too_old(job_id, self.max_job_age)
 
         logger.debug("Shutting down.")
         return 0

--- a/tests/test.py
+++ b/tests/test.py
@@ -193,6 +193,7 @@ class TestDefaultConfig(CompatibleTestCase):
         self.assertEqual(self.config.cuckoo_storage, '/var/lib/peekaboo/.cuckoo/storage')
         self.assertEqual(self.config.cuckoo_url, 'http://127.0.0.1:8090')
         self.assertEqual(self.config.cuckoo_poll_interval, 5)
+        self.assertEqual(self.config.cuckoo_submit_original_filename, True)
         self.assertEqual(self.config.cluster_instance_id, 0)
         self.assertEqual(self.config.cluster_stale_in_flight_threshold, 15*60)
         self.assertEqual(self.config.cluster_duplicate_check_interval, 60)
@@ -232,6 +233,7 @@ submit           :    /submit/1
 storage_path     :    /storage/1
 url              :    http://api:1111
 poll_interval    :    51
+submit_original_filename : no
 
 [cluster]
 instance_id: 12
@@ -263,6 +265,7 @@ duplicate_check_interval: 61
         self.assertEqual(self.config.cuckoo_storage, '/storage/1')
         self.assertEqual(self.config.cuckoo_url, 'http://api:1111')
         self.assertEqual(self.config.cuckoo_poll_interval, 51)
+        self.assertEqual(self.config.cuckoo_submit_original_filename, False)
         self.assertEqual(self.config.cluster_instance_id, 12)
         self.assertEqual(self.config.cluster_stale_in_flight_threshold, 31)
         self.assertEqual(self.config.cluster_duplicate_check_interval, 61)

--- a/tests/test.py
+++ b/tests/test.py
@@ -686,8 +686,9 @@ class MimetypeSample(object):  # pylint: disable=too-few-public-methods
 
 class CuckooReportSample(object):  # pylint: disable=too-few-public-methods
     """ A dummy sample that only contains a configurable cuckoo report. """
-    def __init__(self, report):
+    def __init__(self, report, failed=False):
         self.cuckoo_report = CuckooReport(report)
+        self.cuckoo_failed = failed
 
 
 class TestRules(CompatibleTestCase):


### PR DESCRIPTION
Submission to Cuckoo with the original filename is problematic under
some circumstances. Some are purely technical and arguably bugs that
should be fixed (such as encoding problems), others are operational
(such as intentionally not leaking filenames into the Cuckoo
environment). Either way we should give users the option to choose to
work around technical problems or implement their policy own on original
filenames.

When submitting the original file name to cuckoo, we should also
consider the name of the file in the filesystem, not just the optional
declared name to be more consistent.

Previsously we would only obfuscate the original filename if we could
determine an extension. This was an overly enthusiastic optimisation
that undermined original filename obfuscation towards Cuckoo. Restore
the previous behaviour of always using the sha256sum as basename and
only leaking the file extension because that's required by Cuckoo to
determine the analsysis package (or is it?).

Our current bookkeeping of running Cuckoo jobs did not take into
account that jobs might never finish for whatever reason. This would
leave us accumulating more and more samples in the running jobs list
(think memory leak) and poll endlessly an ever increasing number of
jobs.

This change adds job expiry based on age to the running job list. To
keep the necessary data nicely bundled together we add a class CuckooJob
that uses its creation time as submission time and can be interrogated
as to its age. Otherwise it just stores the sample as before.

Add some wrapper methods to the Cuckoo class to wrap all accesses to the
running jobs list and necessary locking as well as the CuckooJob
abstraction.

Since this expiry might leave client starving, we also need a mechanism
to tell them about our abandoning the job. To achive this we add the
concept of Cuckoo analysis failure to Sample. If we drop a job because
it became too old, we mark the analysis as failed in the sample and
resubmit it to the work queue. In the ruleset we check this failure
marker and return the same error value as for submit errors in the first
place, leading to the same error message which incidentally already
reads that analysis has failed. :)

As a side-effect this finally allows us to fail analysis if we're unable
to get the report of a finished analysis for whatever reason.

Add a configuration option to influence the maximum Cuckoo job age.
Have an explanatory comment regarding its use in the sample
configuration.