### PR TITLE
Content disposition

### DIFF
--- a/amavis/10-ask_peekaboo
+++ b/amavis/10-ask_peekaboo
@@ -49,6 +49,25 @@ use JSON::PP;
 # Yes, Amavis has its own minimalist JSON implementation Amavis::JSON. But it
 # doesn't seem to do UTF-8 encoding correctly - everything ends up as latin1.
 
+# monkey patch a content_disposition setter/getter into the Parts package
+*{Amavis::Unpackers::Part::content_disposition} = sub {
+  @_<2 ? shift->{co_disp} : ($_[0]->{co_disp} = $_[1]);
+};
+
+# monkey patch a wrapper for mime_traverse into the MIME package
+my $amavis_mime_traverse = \&Amavis::Unpackers::MIME::mime_traverse;
+*{Amavis::Unpackers::MIME::mime_traverse} = sub ($$$$$) {
+  my($entity, $tempdir, $parent_obj, $depth, $placement) = @_;
+
+  &$amavis_mime_traverse($entity, $tempdir, $parent_obj, $depth, $placement);
+
+  # go through list of children detected by call above and assign additional
+  # properties
+  foreach my $child (@{$parent_obj->children}) {
+    $child->content_disposition($entity->head->mime_attr('content-disposition'));
+  }
+};
+
 sub ask_peekaboo_internal {
   my ($dummy, $dummy, $names_to_parts, $dummy) = @_;
 
@@ -62,7 +81,7 @@ sub ask_peekaboo_internal {
     my $pmi = {};
 
     my $part = $names_to_parts->{$partname};
-    for my $field (qw( full_name name_declared type_declared )) {
+    for my $field (qw( full_name name_declared type_declared content_disposition )) {
       my $val = $part->$field();
 
       # name_declared can be an array of names, if so use the last

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -112,6 +112,8 @@ class Sample(object):
         # - this way they still somewhat resemble the previous arbitrary
         #   attribute dictionary idea
         # - we'd have to implement the name mangling for setting below
+        # Even though, it is not recommended to access them directly they're an
+        # implementation detail. We add respective properties for that.
         #
         # Security: Add more below to allow them to be accepted from the
         # client. We don't want anyone to be able to pollute our sample
@@ -409,6 +411,12 @@ class Sample(object):
         # extension or the empty string if none found
         self.__file_extension = os.path.splitext(filename)[1][1:]
         return self.__file_extension
+
+    @property
+    def type_declared(self):
+        """ Returns the MIME type declared by the original MIME part, None if
+        not available. """
+        return self.meta_info_type_declared
 
     @property
     def mimetypes(self):

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -111,7 +111,7 @@ class Sample(object):
         # We do not make these private for the following reasons:
         # - this way they still somewhat resemble the previous arbitrary
         #   attribute dictionary idea
-        # - we'd have to implement the name mangling for setting blow
+        # - we'd have to implement the name mangling for setting below
         #
         # Security: Add more below to allow them to be accepted from the
         # client. We don't want anyone to be able to pollute our sample
@@ -119,6 +119,7 @@ class Sample(object):
         # actually use and know how to deal with.
         self.meta_info_name_declared = None
         self.meta_info_type_declared = None
+        self.meta_info_content_disposition = None
 
         self.initialized = False
 
@@ -378,6 +379,12 @@ class Sample(object):
                 self.__sha256sum = checksum
 
         return self.__sha256sum
+
+    @property
+    def content_disposition(self):
+        """ Returns the content disposition in the original email, e.g. inline
+        or attachment, None if not available. """
+        return self.meta_info_content_disposition
 
     @property
     def name_declared(self):

--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -83,15 +83,15 @@ keyword.2 : AutoClose
 #log_level : INFO
 
 expression.1  : sample.mimetypes <= {'text/plain', 'inode/x-empty'} -> ignore
-expression.2  : sample.meta_info_name_declared == /smime.p7[mcs]/
-                    and sample.meta_info_type_declared in {
+expression.2  : sample.name_declared == /smime.p7[mcs]/
+                    and sample.type_declared in {
                         'application/pkcs7-signature',
                         'application/x-pkcs7-signature',
                         'application/pkcs7-mime',
                         'application/x-pkcs7-mime'
                     } -> ignore
-expression.3  : sample.meta_info_name_declared == 'signature.asc'
-                    and sample.meta_info_type_declared in {
+expression.3  : sample.name_declared == 'signature.asc'
+                    and sample.type_declared in {
                         'application/pgp-signature'
                     } -> ignore
 expression.4  : sample.file_extension in {
@@ -104,7 +104,7 @@ expression.4  : sample.file_extension in {
 # as an attachment for the user to open -> no need to scan (if exploiting the
 # mail client is not a concern)
 expression.5  : sample.content_disposition == 'inline'
-                    and sample.mime_types <= {
+                    and sample.type_declared in {
                         'image/png', 'image/jpeg', 'image/gif', 'image/bmp'
                     } -> ignore
 

--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -100,6 +100,13 @@ expression.4  : sample.file_extension in {
                         'xls', 'xlsm', 'xlsx' }
                     and olereport.has_office_macros == True
                     and cuckooreport.score > 4 -> bad
+# inline content will normally be rendered by the mail client and not presented
+# as an attachment for the user to open -> no need to scan (if exploiting the
+# mail client is not a concern)
+expression.5  : sample.content_disposition == 'inline'
+                    and sample.mime_types <= {
+                        'image/png', 'image/jpeg', 'image/gif', 'image/bmp'
+                    } -> ignore
 
 [cuckoo_evil_sig]
 signature.1  : A potential heapspray has been detected. .*

--- a/tests/test.py
+++ b/tests/test.py
@@ -604,10 +604,12 @@ class TestSample(CompatibleTestCase):
                 'full_name': '/tmp/test.pyc',
                 'name_declared': 'test.pyc',
                 'type_declared': 'application/x-bytecode.python',
+                'content_disposition': 'angry',
                 'type_long': 'application/x-python-bytecode',
                 'type_short': 'pyc',
                 'size': '200'})
         self.assertEqual(sample.file_extension, 'pyc')
+        self.assertEqual(sample.content_disposition, 'angry')
 
     def test_sample_without_suffix(self):
         """ Test extraction of file extension from declared name. """

--- a/tests/test.py
+++ b/tests/test.py
@@ -844,7 +844,6 @@ unknown : baz'''
         self.assertEqual(result.result, Result.unknown)
 
         sample = factory.create_sample('file2.gif', 'GIF87...')
-        sample.meta_info_name_declared = None
         rule = ExpressionRule(CreatingConfigParser(config), None)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.ignored)
@@ -854,7 +853,6 @@ unknown : baz'''
         '''
 
         sample = factory.create_sample('file2.gif', 'GIF87...')
-        sample.meta_info_name_declared = None
         rule = ExpressionRule(CreatingConfigParser(config), None)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.ignored)
@@ -862,24 +860,19 @@ unknown : baz'''
     def test_rule_ignore_mail_signatures(self):
         """ Test rule to ignore cryptographic mail signatures. """
         config = '''[expressions]
-            expression.1  : sample.meta_info_name_declared == /smime.p7[mcs]/
-                and sample.meta_info_type_declared in {
+            expression.1  : sample.name_declared == /smime.p7[mcs]/
+                and sample.type_declared in {
                     'application/pkcs7-signature',
                     'application/x-pkcs7-signature',
                     'application/pkcs7-mime',
                     'application/x-pkcs7-mime'
                 } -> ignore
-            expression.2  : sample.meta_info_name_declared == 'signature.asc'
-                and sample.meta_info_type_declared in {
+            expression.2  : sample.name_declared == 'signature.asc'
+                and sample.type_declared in {
                     'application/pgp-signature'
                 } -> ignore
             '''
         rule = ExpressionRule(CreatingConfigParser(config), None)
-
-        part = {"full_name": "p001",
-                "name_declared": "smime.p7s",
-                "type_declared": "application/pkcs7-signature"
-               }
 
         factory = SampleFactory(
             cuckoo=None, base_dir=None, job_hash_regex=None,
@@ -890,37 +883,50 @@ unknown : baz'''
         self.assertEqual(result.result, Result.unknown)
 
         # test smime signatures
+        part = {
+            "full_name": "p001",
+            "name_declared": "smime.p7s",
+            "type_declared": "application/pkcs7-signature"
+        }
+
         sample = factory.make_sample('', metainfo=part)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.ignored)
 
-        sample.meta_info_name_declared = "asmime.p7m"
+        part["name_declared"] = "asmime.p7m"
+        sample = factory.make_sample('', metainfo=part)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 
-        sample.meta_info_name_declared = "smime.p7m"
+        part["name_declared"] = "smime.p7m"
+        sample = factory.make_sample('', metainfo=part)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.ignored)
 
-        sample.meta_info_name_declared = "smime.p7o"
+        part["name_declared"] = "smime.p7o"
+        sample = factory.make_sample('', metainfo=part)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 
-        sample.meta_info_name_declared = "smime.p7"
+        part["name_declared"] = "smime.p7"
+        sample = factory.make_sample('', metainfo=part)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 
-        sample.meta_info_name_declared = "file"
+        part["name_declared"] = "file"
+        sample = factory.make_sample('', metainfo=part)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 
         # test gpg signatures
-        sample.meta_info_name_declared = "signature.asc"
+        part["name_declared"] = "signature.asc"
+        sample = factory.make_sample('', metainfo=part)
         rule = ExpressionRule(CreatingConfigParser(config), None)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 
-        sample.meta_info_type_declared = "application/pgp-signature"
+        part["type_declared"] = "application/pgp-signature"
+        sample = factory.make_sample('', metainfo=part)
         rule = ExpressionRule(CreatingConfigParser(config), None)
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.ignored)


### PR DESCRIPTION
 amavis: Add content disposition to meta info

The content disposition of the original MIME part is interesting for
deciding whether to ignore a sample or not because e.g. inline parts
would likely never be offered to the user for opening with another
application but rendered by the mail client instead.

Add extraction of the content disposition to our amavis plugin by monkey
patching our way around some amavis internals. It's not pretty but
works.

Register the new kind of meta info with Sample and add a property to
access is. Extend the testsuite to check for regressions. Add an example
rule to ruleset.conf.sample.

sample: Make meta info an implementation detail

Direct accesses to the meta_info_* sample member variables have spread
across the codebase again even though they were meant to become an
implementation detail of sample and go away for good eventually.
Therefore we add an accessor property for the declared MIME type and
declare the meta info class members an implementation detail.

Remove usages in the test suite and in expressions in the ruleset.

Fix up the content disposition demo rule with the new type_declared
property, because before we'd augment the mime type list with stuff like
application/octet-stream which made it rather useless. Determining the
need for analysis based solely on criteria the mail client would use
also, like type-declared and content-disposition seems to make more
sense.