### PR TITLE
First 2.0 release candidate

### DIFF
--- a/amavis/10-ask_peekaboo
+++ b/amavis/10-ask_peekaboo
@@ -5,7 +5,7 @@
 # 10-ask_peekaboo
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/bin/dummy_cuckoo.py
+++ b/bin/dummy_cuckoo.py
@@ -7,7 +7,7 @@
 # dummy_cuckoo.py                                                             #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/bin/dummy_cuckoo_submit.py
+++ b/bin/dummy_cuckoo_submit.py
@@ -7,7 +7,7 @@
 # dummy_cuckoo_submit.py                                                      #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/bin/peekaboo-util.py
+++ b/bin/peekaboo-util.py
@@ -8,7 +8,7 @@
 # peekaboo-util.py                                                            #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/bin/scan_emailed_file.py
+++ b/bin/scan_emailed_file.py
@@ -7,7 +7,7 @@
 # scan_emailed_file.py                                                        #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -1,6 +1,6 @@
 #
 # Peekaboo configuration file
-# Copyright (C) 2016-2019 science + computing ag
+# Copyright (C) 2016-2020 science + computing ag
 #
 
 

--- a/peekaboo/__init__.py
+++ b/peekaboo/__init__.py
@@ -25,7 +25,7 @@
 """ Peekaboo constant module data. """
 
 
-VERSION = (1, 7)
+VERSION = (2, '0rc1')
 
 __version__ = '.'.join(map(str, VERSION))
 __author__ = 'Felix Bauer'
@@ -47,11 +47,11 @@ Peekaboo Extended Email Attachment Behavior Observation Owl
                      -*Xa_a_a_WUW##KUL_a_a_aX7'
                     _aXUXUUU4UUX4XX444UUUUUUXLa,
                    _UXXUXUXU47'!'!'!'!*X444U4UXX,
-                   ?XU4U4''   _  _____ -'UUXUUi
-                   ?4U4'     / ||___  |   'UUXi
-                    *Xi      | |   / /     ?X7
-                     *L      | |_ / /       j7
-                      *a     |_(_)_/        jY
+                   ?XU4U4'' ____    ___-'UUXUUi
+                   ?4U4'   |___ \  / _ \  'UUXi
+                    *Xi      __) || | | |  ?X7
+                     *L     / __/ | |_| |   j7
+                      *a   |_____(_)___/    jY
                        -L,                _/'
                          'l,            _/'
                            j7_a_;  aaa/4

--- a/peekaboo/__init__.py
+++ b/peekaboo/__init__.py
@@ -5,7 +5,7 @@
 # __init__.py                                                                 #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #
@@ -30,7 +30,8 @@ VERSION = (1, 7)
 __version__ = '.'.join(map(str, VERSION))
 __author__ = 'Felix Bauer'
 __description__ = 'Peekaboo Extended Email Attachment Behavior Observation Owl'
-__copyright__ = 'Copyright (C) 2016-2019 science + computing ag. All rights reserved.'
+__copyright__ = (
+    'Copyright (C) 2016-2020 science + computing ag. All rights reserved.')
 __license__ = 'GPLv3'
 
 

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -5,7 +5,7 @@
 # config.py                                                                   #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -5,7 +5,7 @@
 # daemon.py                                                                   #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -5,7 +5,7 @@
 # db.py                                                                       #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/exceptions.py
+++ b/peekaboo/exceptions.py
@@ -5,7 +5,7 @@
 # exceptions.py                                                               #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/locale/de/LC_MESSAGES/peekaboo.po
+++ b/peekaboo/locale/de/LC_MESSAGES/peekaboo.po
@@ -1,5 +1,5 @@
 # Peekaboo translations of client-visible strings
-# Copyright (C) 2019 science + computing ag
+# Copyright (C) 2019-2020 science + computing ag
 # Michael Weiser <michael.weiser@gmx.de>
 #
 msgid ""

--- a/peekaboo/queuing.py
+++ b/peekaboo/queuing.py
@@ -5,7 +5,7 @@
 # queuing.py                                                                  #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/ruleset/__init__.py
+++ b/peekaboo/ruleset/__init__.py
@@ -6,7 +6,7 @@
 #         __init__.py                                                         #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/ruleset/engine.py
+++ b/peekaboo/ruleset/engine.py
@@ -6,7 +6,7 @@
 #         engine.py                                                           #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/ruleset/expressions.py
+++ b/peekaboo/ruleset/expressions.py
@@ -6,7 +6,7 @@
 #         expressions.py                                                      #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 # Based on pyparsing's eval_arith.py.
 # Copyright 2009, 2011 Paul McGuire
 #                                                                             #

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -6,7 +6,7 @@
 #         rules.py                                                            #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -5,7 +5,7 @@
 # sample.py                                                                   #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/server.py
+++ b/peekaboo/server.py
@@ -5,7 +5,7 @@
 # server.py                                                                   #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -6,7 +6,7 @@
 #         cuckoo.py                                                           #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/toolbox/file.py
+++ b/peekaboo/toolbox/file.py
@@ -6,7 +6,7 @@
 #         files.py                                                            #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/toolbox/ole.py
+++ b/peekaboo/toolbox/ole.py
@@ -6,7 +6,7 @@
 #         ole.py                                                           #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo/toolbox/peekabooyar.py
+++ b/peekaboo/toolbox/peekabooyar.py
@@ -6,7 +6,7 @@
 #         peekabooyar.py                                                      #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/peekaboo_debug.py
+++ b/peekaboo_debug.py
@@ -7,7 +7,7 @@
 # peekaboo_debug.py                                                           #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -1,6 +1,6 @@
 #
 # Peekaboo ruleset configuration file
-# Copyright (C) 2016-2019 science + computing ag
+# Copyright (C) 2016-2020 science + computing ag
 #
 
 # list of rules to run on samples

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 # setup.py                                                                    #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #

--- a/systemd/peekaboo.service
+++ b/systemd/peekaboo.service
@@ -1,6 +1,6 @@
 #
 # Peekaboo Extended Email Attachment Behavior Observation Owl
-# Copyright (c) 2016-2019 science + computing ag.
+# Copyright (c) 2016-2020 science + computing ag.
 #
 # Install as /etc/systemd/system/peekaboo.service
 #

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,7 +7,7 @@
 # test.py                                                                     #
 ###############################################################################
 #                                                                             #
-# Copyright (C) 2016-2019  science + computing ag                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
 #                                                                             #
 # This program is free software: you can redistribute it and/or modify        #
 # it under the terms of the GNU General Public License as published by        #


### PR DESCRIPTION
I think it's time to do a first release candidate for 2.0 to make it more visible to users and get some feedback before final release.

This changeset updates the version number, including an rc1 suffix and ASCII art (obvs :). The suffix makes pip/PyPI ignore the version by default. So even if we upload it to PyPI (tbd), users would still get 1.7 by default but could explicitly pull 2.0rc1 by running `pip install peekabooav==2.0rc1`.

Make the new year finally happen in Peekiverse while at it.