### PR TITLE
Config access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ See documentation for details.
 - Add database indices to speed up processing and lower database CPU load.
   Rename analyses\_time column to analysis\_time in analysis\_jobs table.
   Raises schema version to 7. (#124)
+- No longer require configuration of a primary group to drop privileges to.
+  Instead use the droppriv user's primary group and supplementary group list by
+  default.
 
 ## 1.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ See documentation for details.
 - No longer require configuration of a primary group to drop privileges to.
   Instead use the droppriv user's primary group and supplementary group list by
   default.
+- Add new options socket\_group and socket\_mode to explicitly open up the
+  socket to client connections with a secure default.
 
 ## 1.7
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 Sphinx
 twine
-pydoctor
+git+https://github.com/twisted/pydoctor.git
 babel
 git-lint
 docutils

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -23,13 +23,37 @@ the files from an email created by AMaViSd:
 
 .. code-block:: shell
 
-    $ gpasswd -a amavis peekaboo
+    $ gpasswd -a peekaboo amavis
 
-**Note**: The group membership only affects direct launch of Peekaboo as that
-user.
-The same convention is implemented in the systemd unit.
-Also, option ``group`` of ``peekaboo.conf`` affects the group Peekaboo changes
-to when started as root.
+**Note**: Extending the supplementary group list of the ``peekaboo`` user is
+the preferred way to achieve access to submitted files.
+A separate group can be employed for that if ``peekaboo`` would otherwise gain
+access to more files than necessary and the client application supports
+changing file ownership to that group before submit.
+Alternatively, option ``group`` of ``peekaboo.conf`` can be used to affect the
+group Peekaboo changes to when started as root.
+
+In order for clients to submit files to Peekaboo, you will need to open its unix
+domain socket up for connections by users other than ``peekaboo``.
+The preferred way for that is to create a separate group, make all users who
+will be submitting files to Peekaboo members of that group and then configure
+the Peekaboo daemon to change group ownership of its socket to that group upon
+startup using option ``socket_group``. Note that the ``peekaboo`` user itself
+needs to be a member of that group in order to be allowed to change ownership
+of its socket to it.
+
+.. code-block:: shell
+
+    $ groupadd -g 151 peekaboo-clients
+    $ gpasswd -a peekaboo peekaboo-clients
+    $ gpasswd -a amavis peekaboo-clients
+
+If there's only a single client, i.e. amavis, the socket owner group can also
+just be its primary group, of which ``peekaboo`` may already be a member in
+order to access submitted files.
+
+It is also possible, although not recommended, to open up the socket to all
+users on the system by adjusting option ``socket_mode``.
 
 You may choose VirtualBox as hypervisor. If so, you must add the Peekaboo user to the
 ``vboxusers`` group.

--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -6,7 +6,8 @@
 
 [global]
 #user             :    peekaboo
-#group            :    peekaboo
+# specific group to drop privileges to if not primary group of user
+#group            :    <empty>
 #socket_file      :    /var/run/peekaboo/peekaboo.sock
 #pid_file         :    /var/run/peekaboo/peekaboo.pid
 #interpreter      :    /usr/bin/python2 -u

--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -9,6 +9,9 @@
 # specific group to drop privileges to if not primary group of user
 #group            :    <empty>
 #socket_file      :    /var/run/peekaboo/peekaboo.sock
+# change socket group and mode to open up client access
+#socket_group     :    <empty>
+#socket_mode      :    0660
 #pid_file         :    /var/run/peekaboo/peekaboo.pid
 #interpreter      :    /usr/bin/python2 -u
 #worker_count     :    3

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -287,7 +287,7 @@ class PeekabooConfig(PeekabooConfigParser):
         # the option should still cope with no or an empty value being handed
         # to it.
         self.user = 'peekaboo'
-        self.group = 'peekaboo'
+        self.group = None
         self.pid_file = '/var/run/peekaboo/peekaboo.pid'
         self.sock_file = '/var/run/peekaboo/peekaboo.sock'
         self.log_level = logging.INFO

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -405,7 +405,9 @@ def run():
         server = PeekabooServer(
             sock_file=config.sock_file, job_queue=job_queue,
             sample_factory=sample_factory,
-            request_queue_size=config.worker_count * 2)
+            request_queue_size=config.worker_count * 2,
+            sock_group=config.sock_group,
+            sock_mode=config.sock_mode)
     except Exception as error:
         logger.critical('Failed to start Peekaboo Server: %s', error)
         job_queue.shut_down()

--- a/systemd/peekaboo.service
+++ b/systemd/peekaboo.service
@@ -12,7 +12,6 @@ After=network.target cuckoo-api.service mysql.service postgresql.service
 
 [Service]
 User=peekaboo
-Group=amavis
 WorkingDirectory=/opt/peekaboo/
 ExecStart=/opt/peekaboo/bin/peekaboo -c /opt/peekaboo/etc/peekaboo.conf -D
 PIDFile=/var/run/peekaboo/peekaboo.pid

--- a/systemd/peekaboo.service
+++ b/systemd/peekaboo.service
@@ -21,7 +21,7 @@ Type=notify
 StandardOutput=journal
 StandardError=journal
 RuntimeDirectory=peekaboo
-RuntimeDirectoryMode=750
+RuntimeDirectoryMode=755
 
 DeviceAllow=/dev/null rw
 CapabilityBoundingSet=~CAP_SYS_PTRACE

--- a/tests/test.py
+++ b/tests/test.py
@@ -169,7 +169,7 @@ class TestDefaultConfig(CompatibleTestCase):
         self.assertEqual(
             self.config.config_file, self.config.created_config_file)
         self.assertEqual(self.config.user, 'peekaboo')
-        self.assertEqual(self.config.group, 'peekaboo')
+        self.assertEqual(self.config.group, None)
         self.assertEqual(
             self.config.sock_file, '/var/run/peekaboo/peekaboo.sock')
         self.assertEqual(

--- a/tests/test.py
+++ b/tests/test.py
@@ -126,6 +126,7 @@ class TestConfigParser(CompatibleTestCase):
 
 [rule1]
 option1: foo
+octal: 0717
 option2.1: bar
 option2.2: baz
 
@@ -140,6 +141,7 @@ rule.3 : rule3
         with self.assertRaises(KeyError):
             self.config['rule0']
         self.assertEqual(self.config['rule1']['option1'], 'foo')
+        self.assertEqual(self.config['rule1'].getoctal('octal'), 0o0717)
         self.assertEqual(self.config['rule1'].getlist('option2'),
                          ['bar', 'baz'])
 
@@ -155,6 +157,18 @@ option1.1: bar'''
                 'given as individual setting'):
             CreatingConfigParser(config).getlist('rule1', 'option1')
 
+    def test_4_octal_mismatch(self):
+        """ Test correct error is thrown if octal format is wrong """
+        config = '''[section]
+nonoctal1: 8
+nonoctal2: deadbeef'''
+
+        for nonoctal in ['nonoctal1', 'nonoctal2']:
+            with self.assertRaisesRegex(
+                    PeekabooConfigException,
+                    'Invalid value for octal option %s in section section: '
+                    % nonoctal):
+                CreatingConfigParser(config).getoctal('section', nonoctal)
 
 
 class TestDefaultConfig(CompatibleTestCase):
@@ -172,6 +186,8 @@ class TestDefaultConfig(CompatibleTestCase):
         self.assertEqual(self.config.group, None)
         self.assertEqual(
             self.config.sock_file, '/var/run/peekaboo/peekaboo.sock')
+        self.assertEqual(self.config.sock_group, None)
+        self.assertEqual(self.config.sock_mode, 0o0660)
         self.assertEqual(
             self.config.pid_file, '/var/run/peekaboo/peekaboo.pid')
         self.assertEqual(self.config.interpreter, '/usr/bin/python2 -u')
@@ -211,6 +227,8 @@ class TestValidConfig(CompatibleTestCase):
 user             :    user1
 group            :    group1
 socket_file      :    /socket/1
+socket_group     :    riddlers
+socket_mode      :    0141
 pid_file         :    /pid/1
 interpreter      :    /inter/1
 worker_count     :    18
@@ -251,6 +269,8 @@ duplicate_check_interval: 61
         self.assertEqual(self.config.user, 'user1')
         self.assertEqual(self.config.group, 'group1')
         self.assertEqual(self.config.sock_file, '/socket/1')
+        self.assertEqual(self.config.sock_group, 'riddlers')
+        self.assertEqual(self.config.sock_mode, 0o0141)
         self.assertEqual(self.config.pid_file, '/pid/1')
         self.assertEqual(self.config.interpreter, '/inter/1')
         self.assertEqual(self.config.worker_count, 18)


### PR DESCRIPTION
To implement scVENUS/PeekabooAV-Installer#28 we need to rework privilege dropping so our droppriv user can have a list of supplementary groups. This changeset does so and activates similar functionality in the systemd service unit by removing the explicit group configuration.