### PR TITLE
Analyser architecture

### DIFF
--- a/analyzers.conf.sample
+++ b/analyzers.conf.sample
@@ -1,0 +1,26 @@
+# Cuckoo analyzer settings
+[cuckoo]
+# where to reach the Cuckoo REST API
+#url: http://127.0.0.1:8090
+
+# how long to wait inbetween checks of job status
+#poll_interval: 5
+
+# Submit samples with their original filenames if available. Enhances
+# authenticity of analysis environment but also leaks original filenames into
+# Cuckoo's database.
+#submit_original_filename : yes
+
+# Specify how long to track running Cuckoo jobs before giving up on them. This
+# does not actively cancel jobs. It's rather meant to handle cases where jobs
+# have for some reason been dropped by or got stuck within Cuckoo. This value
+# is unrelated to how long our client is willing to wait for a result because
+# even if it gives up on us we would normally want to learn and cache the job
+# result because the analysis was expensive and the sample might be presented
+# to us again.
+#maximum_job_age : 900
+
+# From version 2.0.7 cuckoo API has authentication support.
+# New installations create a bearer token by default and require it but upgraded
+# installations don't automatically get one.
+#api_token        :    <empty>

--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -32,6 +32,8 @@
 [ruleset]
 #config           :    /opt/peekaboo/etc/ruleset.conf
 
+[analyzers]
+#config: /opt/peekaboo/etc/analyzers.conf
 
 #
 # Logging configuration
@@ -61,32 +63,6 @@
 # own logging. Can be considered another set of debug logging even beyond
 # Peekaboo's DEBUG log level.
 #log_level        :    WARNING
-
-#
-# Cuckoo specific settings
-#
-[cuckoo]
-#url              :    http://127.0.0.1:8090
-#poll_interval    :    5
-
-# Submit samples with their original filenames if available. Enhances
-# authenticity of analysis environment but also leaks original filenames into
-# Cuckoo's database.
-#submit_original_filename : yes
-
-# Specify how long to track running Cuckoo jobs before giving up on them. This
-# does not actively cancel jobs. It's rather meant to handle cases where jobs
-# have for some reason been dropped by or got stuck within Cuckoo. This value
-# is unrelated to how long our client is willing to wait for a result because
-# even if it gives up on us we would normally want to learn and cache the job
-# result because the analysis was expensive and the sample might be presented
-# to us again.
-#maximum_job_age : 900
-
-# From version 2.0.7 cuckoo API has authentication support.
-# New installations create a bearer token by default and require it but upgraded
-# installations don't automatically get one.
-#api_token        :    <empty>
 
 [cluster]
 # if multiple instances are to run in parallel and avoid concurrent analysis of

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -44,8 +44,8 @@ from peekaboo.db import PeekabooDatabase
 from peekaboo.queuing import JobQueue
 from peekaboo.sample import SampleFactory
 from peekaboo.server import PeekabooServer
-from peekaboo.exceptions import PeekabooDatabaseError, \
-        PeekabooConfigException, PeekabooRulesetConfigError
+from peekaboo.exceptions import (
+    PeekabooDatabaseError, PeekabooConfigException)
 
 
 logger = logging.getLogger(__name__)
@@ -67,10 +67,10 @@ class SignalHandler:
         """
         self.listeners.append(listener)
 
-    def signal_handler(self, sig, frame):
+    def signal_handler(self, sig, _):
         """ catch signal and call appropriate methods in registered listener
         classes """
-        if sig == signal.SIGINT or sig == signal.SIGTERM:
+        if sig in [signal.SIGINT, signal.SIGTERM]:
             logger.debug("SIGINT/TERM")
 
             # these should take serious care about being called across threads

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -47,11 +47,8 @@ class SampleFactory:
     Contains all the global configuration data and object references each
     sample needs and thus serves as a registry of potential API breakage
     perhaps deserving looking into. """
-    def __init__(self, cuckoo, base_dir, job_hash_regex,
+    def __init__(self, base_dir, job_hash_regex,
                  keep_mail_data, processing_info_dir):
-        # object references for interaction
-        self.cuckoo = cuckoo
-
         # configuration
         self.base_dir = base_dir
         self.job_hash_regex = job_hash_regex
@@ -61,7 +58,7 @@ class SampleFactory:
     def make_sample(self, file_path, status_change=None, metainfo=None):
         """ Create a new Sample object based on the factory's configured
         defaults and variable parameters. """
-        return Sample(file_path, self.cuckoo, status_change, metainfo,
+        return Sample(file_path, status_change, metainfo,
                       self.base_dir, self.job_hash_regex, self.keep_mail_data,
                       self.processing_info_dir)
 
@@ -74,14 +71,11 @@ class Sample:
     These are accessible as properties. Most properties determine their value
     on first access, especially if that determination is somewhat expensive
     such as the file checksum.
-
-    The data structure works together with Cuckoo to run behavioral analysis.
     """
-    def __init__(self, file_path, cuckoo=None, status_change=None,
+    def __init__(self, file_path, status_change=None,
                  metainfo=None, base_dir=None, job_hash_regex=None,
                  keep_mail_data=False, processing_info_dir=None):
         self.__path = file_path
-        self.__cuckoo = cuckoo
         self.__wd = None
         self.__filename = os.path.basename(self.__path)
         # A symlink that points to the actual file named
@@ -457,19 +451,6 @@ class Sample:
     def submit_path(self):
         """ Returns the path to use for submission to Cuckoo """
         return self.__submit_path
-
-    def submit_to_cuckoo(self):
-        """ Submit the sample to Cuckoo for analysis and record job id.
-
-        @raises: CuckooAnalsisFailedException if submission failed
-        @returns: cuckoo job id
-        """
-        logger.debug("Submitting %s to Cuckoo", self.__submit_path)
-        cuckoo_job_id = self.__cuckoo.submit(self)
-        self.__internal_report.append(
-            _('Sample %s successfully submitted to Cuckoo as job %d')
-            % (self, cuckoo_job_id))
-        return cuckoo_job_id
 
     def mark_cuckoo_failure(self):
         """ Records whether Cuckoo analysis failed. """

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -97,6 +97,26 @@ class Cuckoo:
     def __init__(self, job_queue, url="http://localhost:8090", api_token="",
                  poll_interval=5, submit_original_filename=True,
                  max_job_age=900, retries=5, backoff=0.5):
+        """ Initialize the object.
+
+        @param job_queue: The job queue to use from now on
+        @type job_queue: JobQueue object
+        @param url: Where to reach the Cuckoo REST API
+        @type url: string
+        @param api_token: API token to use for authentication
+        @type api_token: string
+        @param poll_interval: How long to wait inbetween job status checks
+        @type poll_interval: int
+        @param submit_original_filename: Whether to provide the original
+                                         filename to Cuckoo to enhance analysis.
+        @type submit_original_filename: bool
+        @param max_job_age: How long to track jobs before declaring them failed.
+        @type max_job_age: int (seconds)
+        @param retries: Number of retries on API requests
+        @type retries: int
+        @param backoff: Backoff factor for urllib3
+        @type backoff: float
+        """
         self.job_queue = job_queue
         self.shutdown_requested = threading.Event()
         self.shutdown_requested.clear()
@@ -255,6 +275,14 @@ class Cuckoo:
             self.job_queue.submit(sample, self.__class__)
 
     def submit(self, sample):
+        """ Submit a sample to Cuckoo.
+
+        @param sample: The sample to submit
+        @type sample: Sample object
+        @raises: CuckooSubmitFailedException if submission failed
+        @returns: cuckoo job id """
+        # no use submitting samples to Cuckoo if we cannot resubmit them into
+        # the job queue for continued processing.
         path = sample.submit_path
         filename = os.path.basename(path)
         # override with the original file name if available

--- a/tests/test.py
+++ b/tests/test.py
@@ -813,7 +813,7 @@ class TestRulesetEngine(unittest.TestCase):
         with self.assertRaisesRegex(
                 PeekabooRulesetConfigError,
                 r'No enabled rules found, check ruleset config.'):
-            RulesetEngine(config, None, None, None)
+            RulesetEngine(config, None, None, None).start()
 
     def test_unknown_rule_enabled(self):
         """ Test that correct error is shown if an unknown rule is enabled. """
@@ -822,7 +822,7 @@ rule.1: foo''')
         with self.assertRaisesRegex(
                 PeekabooRulesetConfigError,
                 r'Unknown rule\(s\) enabled: foo'):
-            RulesetEngine(config, None, None, None)
+            RulesetEngine(config, None, None, None).start()
 
     def test_invalid_type(self):
         """ Test that correct error is shown if rule config option has wrong
@@ -836,7 +836,7 @@ higher_than: foo''')
         with self.assertRaisesRegex(
                 ValueError,
                 r"could not convert string to float: '?foo'?"):
-            RulesetEngine(config, None, None, None)
+            RulesetEngine(config, None, None, None).start()
 
     def test_disabled_config(self):
         """ Test that no error is shown if disabled rule has config. """
@@ -847,7 +847,7 @@ rule.1: known
 
 [cuckoo_score]
 higher_than: 4.0''')
-        RulesetEngine(config, None, None, None)
+        RulesetEngine(config, None, None, None).start()
 
 
 class MimetypeSample:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
We have been on a path to remove analyser submission from the Sample.
While it seems like a nice object-oriented concept to say that the sample
submits itself to the analyser, it's not actually the sample driving
this but the ruleset and the benefit of doing it via the sample is very
low (saving the job ID for diagnostics and some logging to the internal
report). The sample basically just served as transport vehicle of the
analyser.

Moving submission into the ruleset removes one layer of indirection and
clarifies sample flow and component interaction.

We could just pass the Cuckoo analyser / job tracker to the ruleset and
be done with it. But since we anticipate to add more analysers that need
long-lived job trackers, we take this opportunity to implement this more
generically: A new analyzer configuration file and object is added which
contains analyzer configuration. Only this configuration is passed to
the ruleset engine. The engine creates the job trackers and hands them
to the rules if they need them. For this each rule is marked by a class
variable or property to need a particular job tracker.

As a nice side-effect, this puts the ruleset engine into a position to
only start job trackers that are actually needed by rules. Expression
mechanics are extended to allow querying whether an expression contains
a particular identifier (independent of whether evaluation will actually
dereference it) so that e.g. the Cuckoo job tracker can be startet if an
expression may request it's report.

Since job trackers may need a reference to the job queue to submit
samples back into it after analysis, the ruleset engine is now created
by the job queue (again) and a reference to the job queue passed into it
for handing to the created job trackers to avoid a circular object
creation order dependency.

Additional changes clean up the code in various places.

In order to be able to shut down quickly during startup we must separate
object creation from initialisation so that the object constructs
quickly, can be registered with the signal handler and then be shut down
quickly during slower resource initialisation. This is particularly true
for the Cuckoo API connectivity test which is now somewhat tucked away
in daemon->queue->ruleset engine->cuckoo.

This also requires to check whether shutdown was requested during this
lengthy initialisation and shut down any resources which may have been
allocated, since they may not have existed yet when the request arrived.
This is employed in the ruleset engine to shut down job trackers.

Also, we add a flag to the signal handler so we can abort startup if
we're asked to shut down again to avoid getting stuck in a
half-inited/half-shut-down state. This problem likely existed all the
time and we just never ran into it.