### PR TITLE
Toolbox: Cortextools Analyser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ See documentation for details.
 
 ## devel
 
+- Introduce cortexreport toolbox analyser to connect to Cortex by TheHive.
+  There already are a few sub analysers that can be used.
+
 ## 2.0
 
 - Embedded Cuckoo mode and python2 support are deprecated now and scheduled for

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -127,3 +127,5 @@ Attribues of cortexreport
     VirusTotalQueryReport.level
     CuckooSandboxFileReport.signatures
     CuckooSandboxFileReport.malscore
+    CAPEv2FileReport.signatures
+    CAPEv2FileReport.malscore

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -115,3 +115,15 @@ Attributes of filereport
     type_by_content
     type_by_name
     type_as_text
+
+Attribues of cortexreport
+-------------------------
+
+.. code-block:: shell
+
+    File_InfoReport.full
+    HybridAnalysisReport.full
+    VirusTotalQueryReport.n_of_all
+    VirusTotalQueryReport.level
+    CuckooSandboxFileReport.signatures
+    CuckooSandboxFileReport.malscore

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -37,6 +37,7 @@ from peekaboo.sample import Sample
 from peekaboo.toolbox.cuckoo import CuckooReport
 from peekaboo.toolbox.ole import Oletools, OletoolsReport
 from peekaboo.toolbox.file import Filetools, FiletoolsReport
+from peekaboo.toolbox.cortex import Cortextools, CortexReport
 
 
 logger = logging.getLogger(__name__)
@@ -147,6 +148,13 @@ class Rule:
         @returns: FiletoolsReport
         """
         return Filetools(sample).get_report()
+
+    def get_cortextools_report(self, sample):
+        """ Get a Cortextools report on the sample.
+
+        @returns: CortextoolsReport
+        """
+        return Cortextools(sample).get_report()
 
 
 class KnownRule(Rule):
@@ -531,6 +539,7 @@ class ExpressionRule(Rule):
                 'cuckooreport': CuckooReport(),
                 'olereport': OletoolsReport(),
                 'filereport': FiletoolsReport(),
+                'cortexreport': CortexReport(),
             }
         }
 
@@ -593,6 +602,9 @@ class ExpressionRule(Rule):
                 elif identifier == "filereport":
                     logger.debug("Expression requests filetools report")
                     value = self.get_filetools_report(sample)
+                elif identifier == "cortexreport":
+                    logger.debug("Expression requests cortextools report")
+                    value = self.get_cortextools_report(sample)
                 # elif here for other identifiers
                 else:
                     return self.result(

--- a/peekaboo/toolbox/cortex.py
+++ b/peekaboo/toolbox/cortex.py
@@ -1,0 +1,229 @@
+###############################################################################
+#                                                                             #
+# Peekaboo Extended Email Attachment Behavior Observation Owl                 #
+#                                                                             #
+# toolbox/                                                                    #
+#         cortex.py                                                           #
+###############################################################################
+#                                                                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
+#                                                                             #
+# This program is free software: you can redistribute it and/or modify        #
+# it under the terms of the GNU General Public License as published by        #
+# the Free Software Foundation, either version 3 of the License, or (at       #
+# your option) any later version.                                             #
+#                                                                             #
+# This program is distributed in the hope that it will be useful, but         #
+# WITHOUT ANY WARRANTY; without even the implied warranty of                  #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU           #
+# General Public License for more details.                                    #
+#                                                                             #
+# You should have received a copy of the GNU General Public License           #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.       #
+#                                                                             #
+###############################################################################
+
+
+import logging
+import time
+
+from cortex4py.api import Api
+
+
+logger = logging.getLogger(__name__)
+
+
+class CortexReport():
+    """ Meta class that joins Cortex analysis JSON report. """
+    def __init__(self, sample=None):
+        self.sample = sample
+
+    @property
+    def File_InfoReport(self):
+        """ Triggers analysis and produces report on access """
+        return File_InfoReport(File_Infotools(self.sample).analyse())
+
+    @property
+    def HybridAnalysisReport(self):
+        """ Triggers analysis and produces report on access """
+        return HybridAnalysisReport(
+            HybridAnalysistools(self.sample).analyse())
+
+    @property
+    def VirusTotalQueryReport(self):
+        """ Triggers analysis and produces report on access """
+        return VirusTotal_QueryReport(
+            VirusTotal_Querytools(self.sample).analyse())
+
+    @property
+    def CuckooSandboxFileReport(self):
+        """ Triggers analysis and produces report on access """
+        return CuckooSandbox_File_AnalysisReport(
+            CuckooSandbox_File_Analysistools(self.sample).analyse()
+        )
+
+
+class Cortextools():
+    """ Interfaces with a Cortex installation via its REST API. """
+    def __init__(self, sample):
+        self.sample = sample
+
+        self.api = Api('http://host:9001', 'BEARERTOKEN')
+        self.analyzers = self.api.analyzers.find_all({}, range='all')
+
+    def get_report(self):
+        return CortexReport(self.sample)
+
+
+class File_Infotools(Cortextools):
+    """ Interfaces with Cortex Analyzer FileInfo_6_0. """
+    def analyse(self):
+        """ Pass file to Cortex Analyzer and wait for report """
+        if not self.sample:
+            return {}
+        job = self.api.analyzers.run_by_name('FileInfo_6_0', {
+            'data': self.sample.file_path,
+            'dataType': 'file',
+            'tlp': 1
+        }, force=1)
+        report = "Waiting"
+        while report in ('Waiting', 'Running'):
+            logger.debug("State of File_Info report generation: %s", report)
+            report = self.api.jobs.get_report(job.id).report
+            time.sleep(5)
+        return report
+
+
+class File_InfoReport():
+    """ Represents a Cortex FileInfo_6_0 analysis JSON report. """
+    def __init__(self, report=None):
+        if report is None:
+            report = {}
+        self.report = report
+
+    @property
+    def full(self):
+        return self.report.get('full', None)
+
+
+class HybridAnalysistools(Cortextools):
+    """ Interfaces with Cortex Analyzer HybridAnalysis_GetReport_1_0. """
+    def analyse(self):
+        """ Pass file to Cortex Analyzer and wait for report """
+        if not self.sample:
+            return {}
+        job = self.api.analyzers.run_by_name('HybridAnalysis_GetReport_1_0', {
+            'data': self.sample.file_path,
+            'dataType': 'file',
+            'tlp': 1,
+            'parameters': {
+                'filename': self.sample.name_declared,
+            }
+        }, force=1)
+        report = "Waiting"
+        while report in ('Waiting', 'Running'):
+            logger.debug("State of HybridAnalysistools report generation: %s",
+                         report)
+            report = self.api.jobs.get_report(job.id).report
+            time.sleep(5)
+        return report
+
+
+class HybridAnalysisReport():
+    """ Represents a Cortex HybridAnalysis_GetReport_1_0 analysis JSON
+        report. """
+    def __init__(self, report=None):
+        if report is None:
+            report = {}
+        self.report = report
+
+    @property
+    def full(self):
+        return self.report.get('full', None)
+
+
+class VirusTotal_Querytools(Cortextools):
+    """ Interfaces with Cortex Analyzer VirusTotal_GetReport_3_0. """
+    def analyse(self):
+        """ Pass file to Cortex Analyzer and wait for report """
+        if not self.sample:
+            return {}
+        job = self.api.analyzers.run_by_name('VirusTotal_GetReport_3_0', {
+            'data': self.sample.sha256sum,
+            'dataType': 'hash',
+            'tlp': 1,
+        }, force=1)
+        report = "Waiting"
+        while report in ('Waiting', 'Running'):
+            logger.debug("State of VirusTotal_querytools report generation: "
+                         "%s", report)
+            report = self.api.jobs.get_report(job.id).report
+            time.sleep(5)
+        return report
+
+
+class VirusTotal_QueryReport():
+    """ Represents a Cortex VirusTotal_GetReport_3_0 analysis JSON report. """
+    def __init__(self, report=None):
+        if report is None:
+            report = {}
+        self.report = report
+        self.taxonomies = report.get("summary", {}).get("taxonomies", [{}])[0]
+
+    @property
+    def n_of_all(self):
+        """ n of all Virusscanners at VirusTotal have rated this file as
+            malicious. """
+        return int(self.taxonomies.get('value', '-1/0').split('/')[0])
+
+    @property
+    def level(self):
+        " safe, suspicious, malicious"
+        return self.taxonomies.get('level', None)
+
+
+class CuckooSandbox_File_Analysistools(Cortextools):
+    """ Interfaces with Cortex Analyzer CuckooSandbox_File_Analysis_Inet_1_2. """
+    def analyse(self):
+        """ Pass file to Cortex Analyzer and wait for report. """
+        if not self.sample:
+            return {}
+        job = self.api.analyzers.run_by_name(
+            'CuckooSandbox_File_Analysis_Inet_1_2', {
+                'data': self.sample.file_path,
+                'dataType': 'file',
+                'tlp': 1,
+                'parameters': {
+                    'filename': self.sample.name_declared,
+                }
+            }, force=1)
+        report = "Waiting"
+        while report in ('Waiting', 'Running'):
+            logger.debug("State of CuckooSandbox_File_Analysistools report "
+                         "generation: %s", report)
+            report = self.api.jobs.get_report(job.id).report
+            time.sleep(5)
+        return report
+
+
+class CuckooSandbox_File_AnalysisReport():
+    """ Represents a Cortex CuckooSandbox_File_Analysis_Inet_1_2 analysis JSON
+        report. """
+    def __init__(self, report=None):
+        if report is None:
+            report = {}
+        self.report = report
+        self.taxonomies = report.get("summary", {}).get("taxonomies", [{}])
+
+    @property
+    def signatures(self):
+        """ Matched Cuckoo signatures. """
+        return self.report.get('full', {}).get('Signatures', None)
+
+    @property
+    def malscore(self):
+        """ Malscore n of 10 (might be bigger). """
+        for t in self.taxonomies:
+            if t.get('predicate') == 'Malscore':
+                return float(t['value'])
+        return -1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ yara-python>=3.6.3
 requests>=2.19.0
 configparser
 pyparsing
+cortex4py

--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -82,6 +82,7 @@ keyword.2 : AutoClose
 # enabled:
 #log_level : INFO
 
+expression.0  : cortexreport.File_InfoReport.full -> bad
 expression.1  : {sample.type_declared}|filereport.mime_types <= {
                     'text/plain', 'inode/x-empty'} -> ignore
 expression.2  : sample.name_declared == /smime.p7[mcs]/
@@ -101,10 +102,15 @@ expression.4  : sample.file_extension in {
                         'xls', 'xlsm', 'xlsx' }
                     and olereport.has_office_macros == True
                     and cuckooreport.score > 4 -> bad
+#expression.5  : cortexreport.VirusTotalQueryReport.n_of_all == 0
+#                    and cortexreport.VirusTotalQueryReport.level == 'safe'
+#                    ->  unknown
+# cortex way to access CuckooSandbox and Malscore
+#expression.6  : cortexreport.CuckooSandboxFileReport.malscore > 6 -> bad
 # inline content will normally be rendered by the mail client and not presented
 # as an attachment for the user to open -> no need to scan (if exploiting the
 # mail client is not a concern)
-expression.5  : sample.content_disposition == 'inline'
+expression.7  : sample.content_disposition == 'inline'
                     and sample.type_declared in {
                         'image/png', 'image/jpeg', 'image/gif', 'image/bmp'
                     } -> ignore


### PR DESCRIPTION
Introduce Cortextools
Adds first shot CAPEv2 sub analyser

Cortex from theHive Project has the ability to connect many Analyzers.
CuckooSandbox amongst them. Also VirusTotal, HybridAnalysis ...

Cortex is now a part of the toolbox and some analyzers can be used in expression
rules.

CAPEv2 can now be used in expressions rules:
expression.0  : cortexreport.CAPEv2FileReport.malscore > 0 -> bad

For now this requires our own CAPEv2 Analyzer installed in Cortex.

For now only the floatingpoint value of malscore and the list of matched signatures are
available.