### PR TITLE
Toolbox: Cortextools Analyser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ See documentation for details.
   Removes tables PeekabooMetadata and AnalysisJournal, and adds field
   analysis\_time to SampleInfo.
 - Generic rules can now make use of the new analyser `knownreport`
+- Introduce cortexreport toolbox analyser to connect to Cortex by TheHive.
+  There already are a few sub analysers that can be used.
 
 ## 2.0
 

--- a/analyzers.conf.sample
+++ b/analyzers.conf.sample
@@ -24,3 +24,28 @@
 # New installations create a bearer token by default and require it but upgraded
 # installations don't automatically get one.
 #api_token        :    <empty>
+
+# Cortex analyzer settings
+[cortex]
+# where to reach the Cortex REST API
+#url: http://127.0.0.1:9001
+
+# Token to authenticate to the Cortex REST API with.
+#api_token        :    <empty>
+
+# how long to wait inbetween checks of job status
+#poll_interval: 5
+
+# Submit samples with their original filenames if available. Enhances
+# authenticity of analysis environment but also leaks original filenames into
+# Cortex's database.
+#submit_original_filename : yes
+
+# Specify how long to track running Cortex jobs before giving up on them. This
+# does not actively cancel jobs. It's rather meant to handle cases where jobs
+# have for some reason been dropped by or got stuck within Cortex. This value
+# is unrelated to how long our client is willing to wait for a result because
+# even if it gives up on us we would normally want to learn and cache the job
+# result because the analysis was expensive and the sample might be presented
+# to us again.
+#maximum_job_age : 900

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -135,3 +135,15 @@ Attributes of knownreport
 
 ``first`` and ``last`` refer to the number of days since this sample was first
 encountered and its last occurrence.
+
+Attribues of cortexreport
+-------------------------
+
+.. code-block:: shell
+
+    File_InfoReport.full
+    HybridAnalysisReport.full
+    VirusTotalQueryReport.n_of_all
+    VirusTotalQueryReport.level
+    CuckooSandboxFileReport.signatures
+    CuckooSandboxFileReport.malscore

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -147,3 +147,5 @@ Attribues of cortexreport
     VirusTotalQueryReport.level
     CuckooSandboxFileReport.signatures
     CuckooSandboxFileReport.malscore
+    CAPEv2FileReport.signatures
+    CAPEv2FileReport.malscore

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -141,7 +141,7 @@ Attribues of cortexreport
 
 .. code-block:: shell
 
-    File_InfoReport.full
+    FileInfoReport.full
     HybridAnalysisReport.full
     VirusTotalQueryReport.n_of_all
     VirusTotalQueryReport.level

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -456,6 +456,12 @@ class PeekabooAnalyzerConfig(PeekabooConfigParser):
         self.cuckoo_submit_original_filename = True
         self.cuckoo_maximum_job_age = 15*60
 
+        self.cortex_url = 'http://127.0.0.1:9001'
+        self.cortex_api_token = ''
+        self.cortex_poll_interval = 5
+        self.cortex_submit_original_filename = True
+        self.cortex_maximum_job_age = 15*60
+
         config_options = {
             'cuckoo_url': ['cuckoo', 'url'],
             'cuckoo_api_token': ['cuckoo', 'api_token'],
@@ -463,6 +469,13 @@ class PeekabooAnalyzerConfig(PeekabooConfigParser):
             'cuckoo_submit_original_filename': [
                 'cuckoo', 'submit_original_filename'],
             'cuckoo_maximum_job_age': ['cuckoo', 'maximum_job_age'],
+
+            'cortex_url': ['cortex', 'url'],
+            'cortex_api_token': ['cortex', 'api_token'],
+            'cortex_poll_interval': ['cortex', 'poll_interval'],
+            'cortex_submit_original_filename': [
+                'cortex', 'submit_original_filename'],
+            'cortex_maximum_job_age': ['cortex', 'maximum_job_age'],
         }
 
         # read configuration file. Note that we require a configuration file

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -196,7 +196,7 @@ class PeekabooDatabase:
 
         # (MySQLdb._exceptions.OperationalError) (2002, "Can't connect to local
         # MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)")
-        if (isinstance(args, tuple) and len(args) > 0 and args[0] in [2002]):
+        if (isinstance(args, tuple) and len(args) > 0 and args[0] in [2002, 2003]):
             # sleep some millisecs
             maxmsecs = self.connect_backoff_base * 2**attempt
             backoff = random.randint(maxmsecs/2, maxmsecs)

--- a/peekaboo/exceptions.py
+++ b/peekaboo/exceptions.py
@@ -63,8 +63,3 @@ class PeekabooAnalysisDeferred(PeekabooRulesetException):
     take into account that the ruleset will be rerun from the very beginning.
     """
     pass
-
-
-class CuckooSubmitFailedException(PeekabooException):
-    """ An exception raised if submitting a job to Cuckoo fails. """
-    pass

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -38,6 +38,7 @@ from peekaboo.toolbox.cuckoo import CuckooReport
 from peekaboo.toolbox.ole import Oletools, OletoolsReport
 from peekaboo.toolbox.file import Filetools, FiletoolsReport
 from peekaboo.toolbox.known import Knowntools, KnowntoolsReport
+from peekaboo.toolbox.cortex import Cortextools, CortexReport
 
 
 logger = logging.getLogger(__name__)
@@ -174,6 +175,13 @@ class Rule:
         @returns: KnowntoolsReport
         """
         return Knowntools(sample, self.db_con).get_report()
+
+    def get_cortextools_report(self, sample):
+        """ Get a Cortextools report on the sample.
+
+        @returns: CortextoolsReport
+        """
+        return Cortextools(sample).get_report()
 
 
 class KnownRule(Rule):
@@ -562,6 +570,7 @@ class ExpressionRule(Rule):
                 'olereport': OletoolsReport(),
                 'filereport': FiletoolsReport(),
                 'knownreport': KnowntoolsReport(),
+                'cortexreport': CortexReport(),
             }
         }
 
@@ -647,6 +656,9 @@ class ExpressionRule(Rule):
                 elif identifier == "knownreport":
                     logger.debug("Expression requests knowntools report")
                     value = self.get_knowntools_report(sample)
+                elif identifier == "cortexreport":
+                    logger.debug("Expression requests cortextools report")
+                    value = self.get_cortextools_report(sample)
                 # elif here for other identifiers
                 else:
                     return self.result(

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -83,6 +83,8 @@ class Sample:
         self.__submit_path = None
         self.__cuckoo_failed = False
         self.__cuckoo_report = None
+        self.__cortex_failed = False
+        self.__cortex_report = None
         self.__oletools_report = None
         self.__filetools_report = None
         self.__knowntools_report = None
@@ -464,6 +466,16 @@ class Sample:
         return self.__cuckoo_report
 
     @property
+    def cortex_failed(self):
+        """ Returns whether a Cortex analysis failed. """
+        return self.__cortex_failed
+
+    @property
+    def cortex_report(self):
+        """ Returns the Cortex report. """
+        return self.__cortex_report
+
+    @property
     def oletools_report(self):
         """ Returns the oletools report """
         return self.__oletools_report
@@ -490,6 +502,14 @@ class Sample:
     def register_cuckoo_report(self, report):
         """ Records a Cuckoo report for later evaluation. """
         self.__cuckoo_report = report
+
+    def mark_cortex_failure(self):
+        """ Records whether Cortex analysis failed. """
+        self.__cortex_failed = True
+
+    def register_cortex_report(self, report):
+        """ Records a Cortex report for later evaluation. """
+        self.__cortex_report = report
 
     def register_oletools_report(self, report):
         """ Records a Oletools report for alter evaluation. """

--- a/peekaboo/toolbox/cortex.py
+++ b/peekaboo/toolbox/cortex.py
@@ -1,0 +1,229 @@
+###############################################################################
+#                                                                             #
+# Peekaboo Extended Email Attachment Behavior Observation Owl                 #
+#                                                                             #
+# toolbox/                                                                    #
+#         cortex.py                                                           #
+###############################################################################
+#                                                                             #
+# Copyright (C) 2016-2020  science + computing ag                             #
+#                                                                             #
+# This program is free software: you can redistribute it and/or modify        #
+# it under the terms of the GNU General Public License as published by        #
+# the Free Software Foundation, either version 3 of the License, or (at       #
+# your option) any later version.                                             #
+#                                                                             #
+# This program is distributed in the hope that it will be useful, but         #
+# WITHOUT ANY WARRANTY; without even the implied warranty of                  #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU           #
+# General Public License for more details.                                    #
+#                                                                             #
+# You should have received a copy of the GNU General Public License           #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.       #
+#                                                                             #
+###############################################################################
+
+
+import logging
+import time
+
+from cortex4py.api import Api
+
+
+logger = logging.getLogger(__name__)
+
+
+class CortexReport():
+    """ Meta class that joins Cortex analysis JSON report. """
+    def __init__(self, sample=None):
+        self.sample = sample
+
+    @property
+    def File_InfoReport(self):
+        """ Triggers analysis and produces report on access """
+        return File_InfoReport(File_Infotools(self.sample).analyse())
+
+    @property
+    def HybridAnalysisReport(self):
+        """ Triggers analysis and produces report on access """
+        return HybridAnalysisReport(
+            HybridAnalysistools(self.sample).analyse())
+
+    @property
+    def VirusTotalQueryReport(self):
+        """ Triggers analysis and produces report on access """
+        return VirusTotal_QueryReport(
+            VirusTotal_Querytools(self.sample).analyse())
+
+    @property
+    def CuckooSandboxFileReport(self):
+        """ Triggers analysis and produces report on access """
+        return CuckooSandbox_File_AnalysisReport(
+            CuckooSandbox_File_Analysistools(self.sample).analyse()
+        )
+
+
+class Cortextools():
+    """ Interfaces with a Cortex installation via its REST API. """
+    def __init__(self, sample):
+        self.sample = sample
+
+        self.api = Api('http://host:9001', 'BEARERTOKEN')
+        self.analyzers = self.api.analyzers.find_all({}, range='all')
+
+    def get_report(self):
+        return CortexReport(self.sample)
+
+
+class File_Infotools(Cortextools):
+    """ Interfaces with Cortex Analyzer FileInfo_6_0. """
+    def analyse(self):
+        """ Pass file to Cortex Analyzer and wait for report """
+        if not self.sample:
+            return {}
+        job = self.api.analyzers.run_by_name('FileInfo_6_0', {
+            'data': self.sample.file_path,
+            'dataType': 'file',
+            'tlp': 1
+        }, force=1)
+        report = "Waiting"
+        while report in ('Waiting', 'Running'):
+            logger.debug("State of File_Info report generation: %s", report)
+            report = self.api.jobs.get_report(job.id).report
+            time.sleep(5)
+        return report
+
+
+class File_InfoReport():
+    """ Represents a Cortex FileInfo_6_0 analysis JSON report. """
+    def __init__(self, report=None):
+        if report is None:
+            report = {}
+        self.report = report
+
+    @property
+    def full(self):
+        return self.report.get('full', None)
+
+
+class HybridAnalysistools(Cortextools):
+    """ Interfaces with Cortex Analyzer HybridAnalysis_GetReport_1_0. """
+    def analyse(self):
+        """ Pass file to Cortex Analyzer and wait for report """
+        if not self.sample:
+            return {}
+        job = self.api.analyzers.run_by_name('HybridAnalysis_GetReport_1_0', {
+            'data': self.sample.file_path,
+            'dataType': 'file',
+            'tlp': 1,
+            'parameters': {
+                'filename': self.sample.name_declared,
+            }
+        }, force=1)
+        report = "Waiting"
+        while report in ('Waiting', 'Running'):
+            logger.debug("State of HybridAnalysistools report generation: %s",
+                         report)
+            report = self.api.jobs.get_report(job.id).report
+            time.sleep(5)
+        return report
+
+
+class HybridAnalysisReport():
+    """ Represents a Cortex HybridAnalysis_GetReport_1_0 analysis JSON
+        report. """
+    def __init__(self, report=None):
+        if report is None:
+            report = {}
+        self.report = report
+
+    @property
+    def full(self):
+        return self.report.get('full', None)
+
+
+class VirusTotal_Querytools(Cortextools):
+    """ Interfaces with Cortex Analyzer VirusTotal_GetReport_3_0. """
+    def analyse(self):
+        """ Pass file to Cortex Analyzer and wait for report """
+        if not self.sample:
+            return {}
+        job = self.api.analyzers.run_by_name('VirusTotal_GetReport_3_0', {
+            'data': self.sample.sha256sum,
+            'dataType': 'hash',
+            'tlp': 1,
+        }, force=1)
+        report = "Waiting"
+        while report in ('Waiting', 'Running'):
+            logger.debug("State of VirusTotal_querytools report generation: "
+                         "%s", report)
+            report = self.api.jobs.get_report(job.id).report
+            time.sleep(5)
+        return report
+
+
+class VirusTotal_QueryReport():
+    """ Represents a Cortex VirusTotal_GetReport_3_0 analysis JSON report. """
+    def __init__(self, report=None):
+        if report is None:
+            report = {}
+        self.report = report
+        self.taxonomies = report.get("summary", {}).get("taxonomies", [{}])[0]
+
+    @property
+    def n_of_all(self):
+        """ n of all Virusscanners at VirusTotal have rated this file as
+            malicious. """
+        return int(self.taxonomies.get('value', '-1/0').split('/')[0])
+
+    @property
+    def level(self):
+        " safe, suspicious, malicious"
+        return self.taxonomies.get('level', None)
+
+
+class CuckooSandbox_File_Analysistools(Cortextools):
+    """ Interfaces with Cortex Analyzer CuckooSandbox_File_Analysis_Inet_1_2. """
+    def analyse(self):
+        """ Pass file to Cortex Analyzer and wait for report. """
+        if not self.sample:
+            return {}
+        job = self.api.analyzers.run_by_name(
+            'CuckooSandbox_File_Analysis_Inet_1_2', {
+                'data': self.sample.file_path,
+                'dataType': 'file',
+                'tlp': 1,
+                'parameters': {
+                    'filename': self.sample.name_declared,
+                }
+            }, force=1)
+        report = "Waiting"
+        while report in ('Waiting', 'Running'):
+            logger.debug("State of CuckooSandbox_File_Analysistools report "
+                         "generation: %s", report)
+            report = self.api.jobs.get_report(job.id).report
+            time.sleep(5)
+        return report
+
+
+class CuckooSandbox_File_AnalysisReport():
+    """ Represents a Cortex CuckooSandbox_File_Analysis_Inet_1_2 analysis JSON
+        report. """
+    def __init__(self, report=None):
+        if report is None:
+            report = {}
+        self.report = report
+        self.taxonomies = report.get("summary", {}).get("taxonomies", [{}])
+
+    @property
+    def signatures(self):
+        """ Matched Cuckoo signatures. """
+        return self.report.get('full', {}).get('Signatures', None)
+
+    @property
+    def malscore(self):
+        """ Malscore n of 10 (might be bigger). """
+        for t in self.taxonomies:
+            if t.get('predicate') == 'Malscore':
+                return float(t['value'])
+        return -1

--- a/peekaboo/toolbox/cortex.py
+++ b/peekaboo/toolbox/cortex.py
@@ -23,157 +23,121 @@
 #                                                                             #
 ###############################################################################
 
+""" Interface to Cortex. """
 
+import datetime
 import logging
-import time
+import os
+import threading
 
-from cortex4py.api import Api
+import cortex4py.api
+import cortex4py.exceptions
+
+from peekaboo.exceptions import PeekabooException
 
 
 logger = logging.getLogger(__name__)
 
 
-class CortexReport():
-    """ Meta class that joins Cortex analysis JSON report. """
-    def __init__(self, sample=None):
-        self.sample = sample
-
-    @property
-    def File_InfoReport(self):
-        """ Triggers analysis and produces report on access """
-        return File_InfoReport(File_Infotools(self.sample).analyse())
-
-    @property
-    def HybridAnalysisReport(self):
-        """ Triggers analysis and produces report on access """
-        return HybridAnalysisReport(
-            HybridAnalysistools(self.sample).analyse())
-
-    @property
-    def VirusTotalQueryReport(self):
-        """ Triggers analysis and produces report on access """
-        return VirusTotal_QueryReport(
-            VirusTotal_Querytools(self.sample).analyse())
-
-    @property
-    def CuckooSandboxFileReport(self):
-        """ Triggers analysis and produces report on access """
-        return CuckooSandbox_File_AnalysisReport(
-            CuckooSandbox_File_Analysistools(self.sample).analyse()
-        )
-
-    @property
-    def CAPEv2FileReport(self):
-        """ Triggers analysis and produces report on access """
-        return CAPEv2_File_AnalysisReport(
-            CAPEv2_File_Analysistools(self.sample).analyse()
-        )
+class CortexSubmitFailedException(PeekabooException):
+    """ An exception raised if submitting a job to Cortex fails. """
 
 
-class Cortextools():
-    """ Interfaces with a Cortex installation via its REST API. """
-    def __init__(self, sample):
-        self.sample = sample
-
-        self.api = Api('http://host:9001', 'BEARERTOKEN')
-        self.analyzers = self.api.analyzers.find_all({}, range='all')
-
-    def get_report(self):
-        return CortexReport(self.sample)
+class CortexAnalyzerReportMissingException(PeekabooException):
+    """ An exception raised if an analysis still needs to be performed. """
+    def __init__(self, analyzer):
+        super().__init__("Cortex analysis report for analyzer '%s' is missing"
+                         % analyzer)
+        self.analyzer = analyzer
 
 
-class File_Infotools(Cortextools):
-    """ Interfaces with Cortex Analyzer FileInfo_6_0. """
-    def analyse(self):
-        """ Pass file to Cortex Analyzer and wait for report """
-        if not self.sample:
-            return {}
-        job = self.api.analyzers.run_by_name('FileInfo_6_0', {
-            'data': self.sample.file_path,
-            'dataType': 'file',
-            'tlp': 1
-        }, force=1)
-        report = "Waiting"
-        while report in ('Waiting', 'Running'):
-            logger.debug("State of File_Info report generation: %s", report)
-            report = self.api.jobs.get_report(job.id).report
-            time.sleep(5)
-        return report
+class CortexAnalyzerReport:
+    """ Cortex analyzer report base class. """
 
 
-class File_InfoReport():
-    """ Represents a Cortex FileInfo_6_0 analysis JSON report. """
-    def __init__(self, report=None):
-        if report is None:
-            report = {}
-        self.report = report
-
-    @property
-    def full(self):
-        return self.report.get('full', None)
+class CortexAnalyzer:
+    """ Cortex analyzer base class. """
+    name = 'unknown'
+    reportclass = CortexAnalyzerReport
 
 
-class HybridAnalysistools(Cortextools):
-    """ Interfaces with Cortex Analyzer HybridAnalysis_GetReport_1_0. """
-    def analyse(self):
-        """ Pass file to Cortex Analyzer and wait for report """
-        if not self.sample:
-            return {}
-        job = self.api.analyzers.run_by_name('HybridAnalysis_GetReport_1_0', {
-            'data': self.sample.file_path,
+class CortexFileAnalyzer:
+    """ An analyzer which accepts a file as main input. """
+    def get_submit_parameters(self, sample, submit_original_filename=False):
+        """ Return this analyzer's submit parameters for a given sample. """
+        path = sample.submit_path
+        filename = os.path.basename(path)
+
+        # override with the original file name if available
+        if submit_original_filename:
+            if sample.name_declared:
+                filename = sample.name_declared
+            elif sample.filename:
+                filename = sample.filename
+
+        params = {
+            'data': path,
             'dataType': 'file',
             'tlp': 1,
             'parameters': {
-                'filename': self.sample.name_declared,
+                'filename': filename,
             }
-        }, force=1)
-        report = "Waiting"
-        while report in ('Waiting', 'Running'):
-            logger.debug("State of HybridAnalysistools report generation: %s",
-                         report)
-            report = self.api.jobs.get_report(job.id).report
-            time.sleep(5)
-        return report
+        }
+
+        return params
 
 
-class HybridAnalysisReport():
-    """ Represents a Cortex HybridAnalysis_GetReport_1_0 analysis JSON
-        report. """
-    def __init__(self, report=None):
-        if report is None:
-            report = {}
+class CortexHashAnalyzer(CortexAnalyzer):
+    """ An analyzer which accepts hashes as main input. """
+    def get_submit_parameters(self, sample, submit_original_filename=False):
+        """ Return this analyzer's submit parameters for a given sample. """
+        params = {
+            'data': sample.sha256sum,
+            'dataType': 'hash',
+            'tlp': 1,
+        }
+
+        return params
+
+
+class FileInfoAnalyzerReport(CortexAnalyzerReport):
+    """ Represents a Cortex FileInfo_7_0 analysis JSON report. """
+    def __init__(self, report):
         self.report = report
 
     @property
     def full(self):
+        """ Return the full report. """
         return self.report.get('full', None)
 
 
-class VirusTotal_Querytools(Cortextools):
-    """ Interfaces with Cortex Analyzer VirusTotal_GetReport_3_0. """
-    def analyse(self):
-        """ Pass file to Cortex Analyzer and wait for report """
-        if not self.sample:
-            return {}
-        job = self.api.analyzers.run_by_name('VirusTotal_GetReport_3_0', {
-            'data': self.sample.sha256sum,
-            'dataType': 'hash',
-            'tlp': 1,
-        }, force=1)
-        report = "Waiting"
-        while report in ('Waiting', 'Running'):
-            logger.debug("State of VirusTotal_querytools report generation: "
-                         "%s", report)
-            report = self.api.jobs.get_report(job.id).report
-            time.sleep(5)
-        return report
+class FileInfoAnalyzer(CortexFileAnalyzer):
+    """ Interfaces with Cortex Analyzer FileInfo_7_0. """
+    name = 'FileInfo_7_0'
+    reportclass = FileInfoAnalyzerReport
 
 
-class VirusTotal_QueryReport():
+class HybridAnalysisReport(CortexAnalyzerReport):
+    """ Represents a Cortex HybridAnalysis_GetReport_1_0 analysis JSON
+        report. """
+    def __init__(self, report):
+        self.report = report
+
+    @property
+    def full(self):
+        """ Return the full report. """
+        return self.report.get('full', None)
+
+
+class HybridAnalysis(CortexFileAnalyzer):
+    """ Interfaces with Cortex Analyzer HybridAnalysis_GetReport_1_0. """
+    name = 'HybridAnalysis_GetReport_1_0'
+    reportclass = HybridAnalysisReport
+
+
+class VirusTotalQueryReport(CortexAnalyzerReport):
     """ Represents a Cortex VirusTotal_GetReport_3_0 analysis JSON report. """
-    def __init__(self, report=None):
-        if report is None:
-            report = {}
+    def __init__(self, report):
         self.report = report
         self.taxonomies = report.get("summary", {}).get("taxonomies", [{}])[0]
 
@@ -185,40 +149,20 @@ class VirusTotal_QueryReport():
 
     @property
     def level(self):
-        " safe, suspicious, malicious"
+        """ safe, suspicious, malicious """
         return self.taxonomies.get('level', None)
 
 
-class CuckooSandbox_File_Analysistools(Cortextools):
-    """ Interfaces with Cortex Analyzer CuckooSandbox_File_Analysis_Inet_1_2. """
-    def analyse(self):
-        """ Pass file to Cortex Analyzer and wait for report. """
-        if not self.sample:
-            return {}
-        job = self.api.analyzers.run_by_name(
-            'CuckooSandbox_File_Analysis_Inet_1_2', {
-                'data': self.sample.file_path,
-                'dataType': 'file',
-                'tlp': 1,
-                'parameters': {
-                    'filename': self.sample.name_declared,
-                }
-            }, force=1)
-        report = "Waiting"
-        while report in ('Waiting', 'Running'):
-            logger.debug("State of CuckooSandbox_File_Analysistools report "
-                         "generation: %s", report)
-            report = self.api.jobs.get_report(job.id).report
-            time.sleep(5)
-        return report
+class VirusTotalQuery(CortexHashAnalyzer):
+    """ Interfaces with Cortex Analyzer VirusTotal_GetReport_3_0. """
+    name = 'VirusTotal_GetReport_3_0'
+    reportclass = VirusTotalQueryReport
 
 
-class CuckooSandbox_File_AnalysisReport():
+class CuckooSandboxFileAnalysisReport(CortexAnalyzerReport):
     """ Represents a Cortex CuckooSandbox_File_Analysis_Inet_1_2 analysis JSON
         report. """
-    def __init__(self, report=None):
-        if report is None:
-            report = {}
+    def __init__(self, report):
         self.report = report
         self.taxonomies = report.get("summary", {}).get("taxonomies", [{}])
 
@@ -230,42 +174,23 @@ class CuckooSandbox_File_AnalysisReport():
     @property
     def malscore(self):
         """ Malscore n of 10 (might be bigger). """
-        for t in self.taxonomies:
-            if t.get('predicate') == 'Malscore':
-                return float(t['value'])
+        for tax in self.taxonomies:
+            if tax.get('predicate') == 'Malscore':
+                return float(tax['value'])
         return -1
 
 
-class CAPEv2_File_Analysistools(Cortextools):
-    """ Interfaces with Cortex Analyzer CAPESandbox_File_Analysis_Inet_0_1. """
-    def analyse(self):
-        """ Pass file to Cortex Analyzer and wait for report. """
-        if not self.sample:
-            return {}
-        job = self.api.analyzers.run_by_name(
-            'CAPESandbox_File_Analysis_Inet_0_1', {
-                'data': self.sample.file_path,
-                'dataType': 'file',
-                'tlp': 1,
-                'parameters': {
-                    'filename': self.sample.name_declared,
-                }
-            }, force=1)
-        report = "Waiting"
-        while report in ('Waiting', 'Running'):
-            logger.debug("State of CAPESandbox_File_Analysis report "
-                         "generation: %s", report)
-            report = self.api.jobs.get_report(job.id).report
-            time.sleep(5)
-        return report
+class CuckooSandboxFileAnalysis(CortexFileAnalyzer):
+    """ Interfaces with Cortex Analyzer CuckooSandbox_File_Analysis_Inet_1_2.
+    """
+    name = 'CuckooSandbox_File_Analysis_Inet_1_2'
+    reportclass = CuckooSandboxFileAnalysisReport
 
 
-class CAPEv2_File_AnalysisReport():
+class CAPEv2FileAnalysisReport(CortexAnalyzerReport):
     """ Represents a Cortex CAPESandbox_File_Analysis_Inet_0_1 analysis JSON
         report. """
-    def __init__(self, report=None):
-        if report is None:
-            report = {}
+    def __init__(self, report):
         self.report = report
         self.taxonomies = report.get("summary", {}).get("taxonomies", [{}])
 
@@ -277,7 +202,336 @@ class CAPEv2_File_AnalysisReport():
     @property
     def malscore(self):
         """ Malscore n of 10 (might be bigger). """
-        for t in self.taxonomies:
-            if t.get('predicate') == 'Malscore':
-                return float(t['value'])
+        for tax in self.taxonomies:
+            if tax.get('predicate') == 'Malscore':
+                return float(tax['value'])
         return -1
+
+
+class CAPEv2FileAnalysis(CortexFileAnalyzer):
+    """ Interfaces with Cortex Analyzer CAPESandbox_File_Analysis_Inet_0_1. """
+    name = 'CAPESandbox_File_Analysis_Inet_0_1'
+    reportclass = CAPEv2FileAnalysisReport
+
+
+class CortexReport:
+    """ Meta class that either returns Cortex analysis reports or requests an
+    analysis to be performed if it's not available yet. """
+    def __init__(self):
+        """ Initialize the report object. """
+        self.reports = {}
+
+    def register_report(self, analyzer, report):
+        """ Register a report from an analyzer.
+
+        @param analyzer: The analyzer the report is from.
+        @type analyzer: CortexAnalyzer
+        @param report: The report dict as returned by the API.
+        @type report: dict
+        """
+        if analyzer.name in self.reports:
+            logger.warning('Analysis report for %s already present - '
+                           'replacing.', analyzer.name)
+
+        self.reports[analyzer.name] = analyzer.reportclass(report)
+
+    def get_report(self, analyzer):
+        """ Try to retrieve an analyzer report from the sample.
+
+        @param analyzer: Name of the analyzer
+        @type analyzer: string
+        @returns: CortexAnalyzerReport if present
+        @raises: CortexAnalyzerReportMissingException if the report is not
+                 yet present.
+        """
+        report = self.reports.get(analyzer.name)
+        if report is None:
+            raise CortexAnalyzerReportMissingException(analyzer)
+
+        return report
+
+    @property
+    def FileInfoReport(self):
+        """ Retrieve FileInfo analyzer report. """
+        return self.get_report(FileInfoAnalyzer())
+
+    @property
+    def HybridAnalysisReport(self):
+        """ Retrieve HybridAnalysis analyzer report. """
+        return self.get_report(HybridAnalysis())
+
+    @property
+    def VirusTotalQueryReport(self):
+        """ Retrieve VirusTotalQuery analyzer report. """
+        return self.get_report(VirusTotalQuery())
+
+    @property
+    def CuckooSandboxFileReport(self):
+        """ Retrieve CuckooSandboxFile analyzer report. """
+        return self.get_report(CuckooSandboxFileAnalysis())
+
+    @property
+    def CAPEv2FileReport(self):
+        """ Retrieve CAPEv2File analyzer report. """
+        return self.get_report(CAPEv2FileAnalysis())
+
+
+class CortexJob:
+    """ Remember sample and submission time of a Cortex job. """
+    def __init__(self, sample, analyzer):
+        """ Initialise the CortexJob wrapper.
+
+        @param sample: The sample in analysis.
+        @type sample: Sample
+        @param job: The Cortex analysis job
+        @type job: cortex4py.controllers.JobController
+        @param analyzer: Our analyzer object
+        @type analyzer: CortexAnalyzer
+        """
+        self.__sample = sample
+        self.__submission_time = datetime.datetime.utcnow()
+        self.__analyzer = analyzer
+
+    def is_older_than(self, seconds):
+        """ Returns True if the difference between submission time and now,
+        i.e. the age of the job, is larger than given number of seconds. """
+        max_age = datetime.timedelta(seconds=seconds)
+        return datetime.datetime.utcnow() - self.__submission_time > max_age
+
+    @property
+    def sample(self):
+        """ Returns the sample the job is analyzing. """
+        return self.__sample
+
+    @property
+    def analyzer(self):
+        """ Returns the analyzer used to analyse the sample. """
+        return self.__analyzer
+
+
+class Cortex:
+    """ Interfaces with a Cortex installation via its REST API. """
+    def __init__(self, job_queue, url="http://localhost:9001", api_token="",
+                 poll_interval=5, submit_original_filename=True,
+                 max_job_age=900):
+        """ Initialize the object.
+
+        @param job_queue: The job queue to use from now on
+        @type job_queue: JobQueue object
+        @param url: Where to reach the Cortex REST API
+        @type url: string
+        @param api_token: API token to use for authentication
+        @type api_token: string
+        @param poll_interval: How long to wait inbetween job status checks
+        @type poll_interval: int
+        @param submit_original_filename: Whether to provide the original
+                                         filename to Cortex to enhance
+                                         analysis.
+        @type submit_original_filename: bool
+        @param max_job_age: How long to track jobs before declaring them
+                            failed.
+        @type max_job_age: int (seconds)
+        """
+        self.job_queue = job_queue
+        self.shutdown_requested = threading.Event()
+        self.shutdown_requested.clear()
+        self.running_jobs = {}
+        # reentrant because we're doing nested calls within critical sections
+        self.running_jobs_lock = threading.RLock()
+        self.url = url
+        self.api_token = api_token
+        self.poll_interval = poll_interval
+        self.submit_original_filename = submit_original_filename
+        self.max_job_age = max_job_age
+
+        self.api = None
+        self.tracker = None
+
+    def register_running_job(self, job_id, job):
+        """ Register a job as running. Detect if another sample has already
+        been registered with the same job ID which obviously must never happen
+        because it corrupts our internal housekeeping. Guarded by a lock
+        because multiple worker threads will call this routine and check for
+        collision and update of job log might otherwise race each other.
+
+        @param job_id: Cortex job ID of the job to register as running.
+        @type job_id: string
+        @param job: Our Cortex job wrapper object
+        @type job: CortexJob
+
+        @returns: None
+        @raises: CortexSubmitFailedException on job id collision """
+        with self.running_jobs_lock:
+            if (job_id in self.running_jobs and
+                    self.running_jobs[job_id] is not job):
+                raise CortexSubmitFailedException(
+                    'A job with ID %s is already registered as running '
+                    'for sample %s' % (job_id, self.running_jobs[job_id]))
+
+            self.running_jobs[job_id] = job
+
+    def deregister_running_job(self, job_id):
+        """ Deregister a running job by job id.
+
+        @param job_id: Cortex job ID of the job do deregister.
+        @type job_id: string
+        @returns: Sample object of the job or None if job not found. """
+        with self.running_jobs_lock:
+            return self.running_jobs.pop(job_id, None)
+
+    def deregister_running_job_if_too_old(self, job_id, max_age):
+        """ Check if a job has gotten too old and remove it from the list of
+        running jobs if so.
+
+        @param job_id: Cortex job ID of the job do deregister.
+        @type job_id: string
+        @returns: Sample object of the job or None if job not found. """
+        with self.running_jobs_lock:
+            if self.running_jobs[job_id].is_older_than(max_age):
+                return self.deregister_running_job(job_id)
+
+        return None
+
+    def resubmit_with_analyzer_report(self, job_id):
+        """ Resubmit a sample to the job queue after an analyzer report became
+        available. Retrieves the report from Cortex.
+
+        @param job_id: ID of job which has finished.
+        @type job_id: string
+        @param report: Analyzer report
+        @type report: dict
+
+        @returns: None
+        """
+        logger.debug("Analysis done for job %s", job_id)
+
+        job = self.deregister_running_job(job_id)
+        if job is None:
+            logger.debug('No job found for job ID %s', job_id)
+            return None
+
+        logger.debug('Requesting Cortex report for sample %s', job.sample)
+        try:
+            report = self.api.jobs.get_report(job_id)
+            # register this job's analysis report with our main report object
+            job.sample.cortex_report.register_report(
+                job.analyzer, report.report)
+        # FIXME: More error handling and retrying here
+        except cortex4py.exceptions.CortexException:
+            # mark analysis as failed if we could not get the report e.g.
+            # because it was corrupted or the API connection failed.
+            job.sample.mark_cortex_failure()
+
+        self.job_queue.submit(job.sample, self.__class__)
+        return None
+
+    def resubmit_as_failed(self, job_id):
+        """ Resubmit a sample to the job queue with a failure report if the
+        Cortex job has failed for some reason.
+
+        @param job_id: ID of job that failed.
+        @type job_id: string
+        """
+        job = self.deregister_running_job(job_id)
+        if job is not None:
+            logger.warning("Dropped job %s because it has failed in Cortex",
+                           job_id)
+            job.sample.mark_cortex_failure()
+            self.job_queue.submit(job.sample, self.__class__)
+
+    def resubmit_as_failed_if_too_old(self, job_id, max_age):
+        """ Resubmit a sample to the job queue with a failure report if the
+        Cortex job has been running for too long.
+
+        @param job_id: ID of job to check.
+        @type job_id: string
+        @param max_age: maximum job age in seconds
+        @type max_age: int
+        """
+        job = self.deregister_running_job_if_too_old(job_id, max_age)
+        if job is not None:
+            logger.warning("Dropped job %s because it has been running for "
+                           "too long", job_id)
+            job.sample.mark_cortex_failure()
+            self.job_queue.submit(job.sample, self.__class__)
+
+    def submit(self, sample, analyzer):
+        """ Submit a sample to Cortex for analysis.
+        @param sample: Sample to submit.
+        @type sample: Sample
+
+        @raises: CortexSubmitFailedException if submission failed
+        @returns: ID of the submitted Cortex job.
+        """
+        params = analyzer.get_submit_parameters(
+            sample, self.submit_original_filename)
+
+        logger.debug("Creating Cortex job with analyzer %s and "
+                     "parameters %s", analyzer.name, params)
+        job = self.api.analyzers.run_by_name(analyzer.name, params)
+        self.register_running_job(job.id, CortexJob(sample, analyzer))
+        return job.id
+
+    def start_tracker(self):
+        """ Start tracking running jobs in a separate thread. """
+        # do a simple initial test of connectivity. With this we require the
+        # API to be reachable at startup (with the usual retries to account for
+        # a bit of a race condition in parallel startup) but later on hope
+        # that all errors are transient and retry endlessly
+        self.api = cortex4py.api.Api(self.url, self.api_token)
+        self.api.analyzers.find_all({}, range='all')
+
+        self.tracker = threading.Thread(target=self.track,
+                                        name="CortexJobTracker")
+        self.tracker.start()
+        return True
+
+    def track(self):
+        """ Do the polling for finished jobs. """
+        while not self.shutdown_requested.wait(self.poll_interval):
+            # no lock, atomic, copy() because keys() returns an iterable view
+            # instead of a fresh new list in python3
+            running_jobs = self.running_jobs.copy().keys()
+
+            # somewhat inefficient for the potential number of requests per
+            # poll round but more efficient in that it does not download an
+            # ever growing list of jobs using tasks/list. Might also take
+            # quite a while to get to all jobs if retries happen on each
+            # request.
+            # A call to get data about multiple tasks in one go would be nice
+            # here. tasks/list could be used with the minimum job number as
+            # offset and spread between highest and lowest job id as limit *if*
+            # its output was sorted by job ID. Apparently limit and offset are
+            # only meant to iterate over the job list in blocks but not to
+            # return data about a specific range of job IDs from that list.
+            for job_id in running_jobs:
+                cortexjob = self.api.jobs.get_by_id(job_id)
+                if cortexjob.status in ['Success']:
+                    self.resubmit_with_analyzer_report(job_id)
+                    continue
+
+                if cortexjob.status in ['Failure', 'Deleted']:
+                    self.resubmit_as_failed(job_id)
+                    continue
+
+                # drop jobs which have been running for too long. This is
+                # mainly to prevent accumulation of jobs in our job list which
+                # will never finish. We still want to wait for jobs to finish
+                # even though our client might not be interested any more so
+                # that we have the result cached for the next time we get the
+                # same sample.
+                self.resubmit_as_failed_if_too_old(job_id, self.max_job_age)
+
+        logger.debug("Cortex job tracker shut down.")
+
+    def shut_down(self):
+        """ Request the module to shut down, used by the signal handler. """
+        logger.debug("Cortex job tracker shutdown requested.")
+        self.shutdown_requested.set()
+
+    def close_down(self):
+        """ Close down tracker resources, particularly, wait for the thread to
+        terminate. """
+        if self.tracker:
+            self.tracker.join()
+            self.tracker = None

--- a/peekaboo/toolbox/cortex.py
+++ b/peekaboo/toolbox/cortex.py
@@ -57,6 +57,18 @@ class CortexAnalyzerReportMissingException(PeekabooException):
 class CortexAnalyzerReport:
     """ Cortex analyzer report base class. """
 
+    @classmethod
+    def get_element_from_list_of_dicts(cls, list_, ident_key, ident_value, default={}):
+        #pylint: disable=dangerous-default-value
+        """ Search a list of dicts for an element with a matching value for an
+            identifying key """
+        element = [dictionary for dictionary in list_
+            if dictionary.get(ident_key) == ident_value
+        ]
+        if len(element) != 1:
+            return default
+        return element[0]
+
 
 class CortexAnalyzer:
     """ Cortex analyzer base class. """
@@ -142,18 +154,21 @@ class VirusTotalQueryReport(CortexAnalyzerReport):
     """ Represents a Cortex VirusTotal_GetReport_3_0 analysis JSON report. """
     def __init__(self, report):
         self.report = report
-        self.taxonomies = report.get("summary", {}).get("taxonomies", [{}])[0]
+        self.taxonomies_vt = self.get_element_from_list_of_dicts(
+                report.get('summary', {}).get('taxonomies'),
+                'namespace', 'VT', {}
+            )
 
     @property
     def n_of_all(self):
         """ n of all Virusscanners at VirusTotal have rated this file as
             malicious. """
-        return int(self.taxonomies.get('value', '-1/0').split('/')[0])
+        return int(self.taxonomies_vt.get('value', '-1/0').split('/')[0])
 
     @property
     def level(self):
         """ safe, suspicious, malicious """
-        return self.taxonomies.get('level', None)
+        return self.taxonomies_vt.get('level', None)
 
 
 class VirusTotalQuery(CortexHashAnalyzer):

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -33,10 +33,15 @@ import threading
 import requests
 import urllib3.util.retry
 
-from peekaboo.exceptions import CuckooSubmitFailedException
+from peekaboo.exceptions import PeekabooException
 
 
 logger = logging.getLogger(__name__)
+
+
+class CuckooSubmitFailedException(PeekabooException):
+    """ An exception raised if submitting a job to Cuckoo fails. """
+    pass
 
 
 class CuckooJob:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ yara-python>=3.6.3
 requests>=2.19.0
 configparser
 pyparsing
+cortex4py

--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -84,6 +84,7 @@ keyword.2 : AutoClose
 
 #expression.0  : knownreport.known -> knownreport.result
 #expression.0  : knownreport.known and knownreport.first < 14 -> knownreport.result
+#expression.0  : cortexreport.File_InfoReport.full -> bad
 expression.1  : {sample.type_declared}|filereport.mime_types <= {
                     'text/plain', 'inode/x-empty'} -> ignore
 expression.2  : sample.name_declared == /smime.p7[mcs]/
@@ -103,10 +104,15 @@ expression.4  : sample.file_extension in {
                         'xls', 'xlsm', 'xlsx' }
                     and olereport.has_office_macros == True
                     and cuckooreport.score > 4 -> bad
+#expression.5  : cortexreport.VirusTotalQueryReport.n_of_all == 0
+#                    and cortexreport.VirusTotalQueryReport.level == 'safe'
+#                    ->  unknown
+# cortex way to access CuckooSandbox and Malscore
+#expression.6  : cortexreport.CuckooSandboxFileReport.malscore > 6 -> bad
 # inline content will normally be rendered by the mail client and not presented
 # as an attachment for the user to open -> no need to scan (if exploiting the
 # mail client is not a concern)
-expression.5  : sample.content_disposition == 'inline'
+expression.7  : sample.content_disposition == 'inline'
                     and sample.type_declared in {
                         'image/png', 'image/jpeg', 'image/gif', 'image/bmp'
                     } -> ignore

--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -84,7 +84,7 @@ keyword.2 : AutoClose
 
 #expression.0  : knownreport.known -> knownreport.result
 #expression.0  : knownreport.known and knownreport.first < 14 -> knownreport.result
-#expression.0  : cortexreport.File_InfoReport.full -> bad
+#expression.0  : cortexreport.FileInfoReport.full -> bad
 expression.1  : {sample.type_declared}|filereport.mime_types <= {
                     'text/plain', 'inode/x-empty'} -> ignore
 expression.2  : sample.name_declared == /smime.p7[mcs]/

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
             "CHANGELOG.md",
             "peekaboo.conf.sample",
             "ruleset.conf.sample",
+            "analyzers.conf.sample",
         ]),
         ("share/doc/peekaboo/systemd", [
             "systemd/peekaboo.service",

--- a/tests/test.py
+++ b/tests/test.py
@@ -337,6 +337,11 @@ class TestDefaultAnalyzerConfig(unittest.TestCase):
         self.assertEqual(self.config.cuckoo_submit_original_filename, True)
         self.assertEqual(self.config.cuckoo_maximum_job_age, 900)
         self.assertEqual(self.config.cuckoo_api_token, '')
+        self.assertEqual(self.config.cortex_url, 'http://127.0.0.1:9001')
+        self.assertEqual(self.config.cortex_poll_interval, 5)
+        self.assertEqual(self.config.cortex_submit_original_filename, True)
+        self.assertEqual(self.config.cortex_maximum_job_age, 900)
+        self.assertEqual(self.config.cortex_api_token, '')
 
 
 class TestValidAnalyzerConfig(unittest.TestCase):
@@ -349,7 +354,14 @@ url: http://api:1111
 poll_interval: 51
 submit_original_filename: no
 maximum_job_age: 900
-api_token: tok''')
+api_token: tok
+
+[cortex]
+url: http://api:2222
+poll_interval: 57
+submit_original_filename: yes
+maximum_job_age: 905
+api_token: tok2''')
 
     def test_1_read_settings(self):
         """ Test reading of configuration settings from file """
@@ -358,6 +370,12 @@ api_token: tok''')
         self.assertEqual(self.config.cuckoo_submit_original_filename, False)
         self.assertEqual(self.config.cuckoo_maximum_job_age, 900)
         self.assertEqual(self.config.cuckoo_api_token, 'tok')
+
+        self.assertEqual(self.config.cortex_url, 'http://api:2222')
+        self.assertEqual(self.config.cortex_poll_interval, 57)
+        self.assertEqual(self.config.cortex_submit_original_filename, True)
+        self.assertEqual(self.config.cortex_maximum_job_age, 905)
+        self.assertEqual(self.config.cortex_api_token, 'tok2')
 
 
 class CreatingSampleFactory(SampleFactory):


### PR DESCRIPTION
Introduce Cortextools
Adds first shot CAPEv2 sub analyser

Cortex from theHive Project has the ability to connect many Analyzers.
CuckooSandbox amongst them. Also VirusTotal, HybridAnalysis ...

Cortex is now a part of the toolbox and some analyzers can be used in expression
rules.

CAPEv2 can now be used in expressions rules:
expression.0 : cortexreport.CAPEv2FileReport.malscore > 0 -> bad

For now this requires our own CAPEv2 Analyzer installed in Cortex.

For now only the floatingpoint value of malscore and the list of matched signatures are
available.