### PR TITLE
Uri filenames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
+  - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 
 install:
   - pip install -r requirements.txt

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -416,10 +416,22 @@ class Sample:
         # - allow only alphanumeric characters and some symbols (arbitrarily
         #   chosen based on file extension list in Wikipedia and personal
         #   experience)
-        # indirectly by stripping what is allowed from the extension and
-        # checking that nothing remains.
-        if ext.strip(
-                string.ascii_letters + string.digits + string.punctuation):
+        allowed_characters = string.ascii_letters + string.digits
+
+        # we're seeing attachments whose declared filenames include what seems
+        # to be meant as query strings (e.g. foo.jpg?resize=600,510). Since
+        # there are no file extensions we know of containing those characters,
+        # we do not allow them. Since we cannot find any document stating that
+        # the name parameter of header Content-Type can contain URLs/URIs,
+        # we're not even attempting to go down the rabbit hole of parsing it as
+        # such to avoid the inevitable fallout from it. Instead we rather not
+        # extract any extension at all.
+        allowed_characters += string.punctuation.translate(
+                str.maketrans('', '', '?;&'))
+
+        # test works indirectly by stripping what is allowed from beginning and
+        # end of the extension and checking that nothing remains.
+        if ext.strip(allowed_characters):
             return None
 
         self.__file_extension = ext

--- a/peekaboo/toolbox/ole.py
+++ b/peekaboo/toolbox/ole.py
@@ -74,11 +74,11 @@ class Oletools:
                 for (_, _, _, c) in vb_code:
                     autoexec = detect_autoexec(c)
                     if len(autoexec) >= 1:
-                        report['autoexec'].append(autoexec[0])
+                        report['autoexec'].extend(autoexec)
 
                     suspicious = detect_suspicious(c)
                     if len(suspicious) >= 1:
-                        report['suspicious'].append(suspicious[0])
+                        report['suspicious'].extend(suspicious)
 
             vbaparser.close()
         except IOError:

--- a/tests/test.py
+++ b/tests/test.py
@@ -682,6 +682,9 @@ class TestSample(unittest.TestCase):
             ['foo1%', True],
             ['foo 1', False],
             ['fü', False],
+            ['foo&resize=600,510', False],
+            ['foo;param=5', False],
+            ['foo?query=value', False],
         ]
 
         for ext, accepted in testcases:

--- a/tests/test.py
+++ b/tests/test.py
@@ -726,7 +726,10 @@ class TestOletools(unittest.TestCase):
         cases = [
             # file name, , vba code, , detected autoexec, , detected suspicious
             #     , has macros, , has autoexec, , is suspicious,
-            ['blank.doc', False, '', False, '[]', False, '[]'],
+            ['blank.doc', False, r'^$', False, r'^\[\]$', False, r'^\[\]$'],
+            ['CheckVM.xls', True, r'^Private Sub Workbook_Open\(\)',
+                True, r'''^\[.*\('Workbook_Open', 'Runs when''',
+                True, r'''^\[.*\('GetObject', 'May get an'''],
         ]
         for file_name, expected_has_office_macros, expected_vba_code, \
                 expected_has_autoexec, expected_detected_autoexec, \
@@ -736,19 +739,19 @@ class TestOletools(unittest.TestCase):
             self.assertEqual(
                 report.has_office_macros, expected_has_office_macros,
                 "Oletools has_office_macros: %s" % file_name)
-            self.assertEqual(
+            self.assertRegex(
                 report.vba_code, expected_vba_code,
                 "Oletools expected_vba_code: %s" % file_name)
             self.assertEqual(
                 report.has_autoexec, expected_has_autoexec,
                 "Oletools has_autoexec: %s" % file_name)
-            self.assertEqual(
+            self.assertRegex(
                 report.detected_autoexec, expected_detected_autoexec,
                 "Oletools detected_autoexec: %s" % file_name)
             self.assertEqual(
                 report.is_suspicious, expected_is_suspicious,
                 "Oletools is_suspicious: %s" % file_name)
-            self.assertEqual(
+            self.assertRegex(
                 report.detected_suspicious, expected_detected_suspicious,
                 "Oletools detected_autoexec: %s" % file_name)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -219,7 +219,7 @@ config           :    /rules/1
 
 [logging]
 log_level        :    DEBUG
-log_format       :    format%%foo1
+log_format       :    format%%(foo1)s
 
 [db]
 url              :    sqlite:////peekaboo.db1
@@ -247,7 +247,7 @@ duplicate_check_interval: 61
         self.assertEqual(self.config.processing_info_dir, '/var/3')
         self.assertEqual(self.config.ruleset_config, '/rules/1')
         self.assertEqual(self.config.log_level, logging.DEBUG)
-        self.assertEqual(self.config.log_format, 'format%foo1')
+        self.assertEqual(self.config.log_format, 'format%(foo1)s')
         self.assertEqual(self.config.db_url, 'sqlite:////peekaboo.db1')
         self.assertEqual(self.config.cluster_instance_id, 12)
         self.assertEqual(self.config.cluster_stale_in_flight_threshold, 31)


### PR DESCRIPTION
We're seeing attachments whose declared filenames include what seems to
be meant as query strings (e.g. foo.jpg?resize=600,510). Since there
are no file extensions we know of containing those characters, we do not
allow them. Since we cannot find any document stating that the name
parameter of header Content-Type can contain URLs/URIs, we're not even
attempting to go down the rabbit hole of parsing it as such to avoid the
inevitable fallout from it. Instead we rather not extract any extension
at all.

As a prerequisite for testing with the testsuite two independent patches fix issues
in the testsuite with python 3.8 and from that an actual behavioural problem with
our oletools code uncovered by a now failing test.