### PR TITLE
expressions: More natural equality matching of regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ See documentation for details.
 
 ## devel
 
+- Breaking change: Equality operators in expressions using regexes do now need
+  to match the whole string up to the end.
 - New database schema version 8.
   Removes tables PeekabooMetadata and AnalysisJournal, and adds field
   analysis\_time to SampleInfo.

--- a/peekaboo/ruleset/expressions.py
+++ b/peekaboo/ruleset/expressions.py
@@ -132,7 +132,17 @@ class EvalString(EvalBase):
 class OperatorRegex:
     """ A class implementing operators on regular expressions. """
     def __init__(self, string):
-        self.regex = re.compile(string)
+        # We use re.search to implement the membership operator (in) in the
+        # sense of "matches anywhere in the string". We can use the regex
+        # as given for that.
+        self.membership_regex = re.compile(string)
+        # For equality matches we use re.match which already anchors the
+        # matching at the start of the operand but does not require a match all
+        # up until the end of it. So we need to add an explicit end-of-line anchor.
+        self.equality_regex = re.compile("%s$" % string)
+        # NOTE: Take the multiline semantics of re.search vs. re.match into
+        # account when looking to change this (although we're not using
+        # multiline mode as of now).
 
     @staticmethod
     def compare_op_impl(function, other):
@@ -152,18 +162,21 @@ class OperatorRegex:
 
     def __eq__(self, other):
         """ Implement equality using re.match """
-        logger.debug("Regular expression match: %s == %s", self.regex, other)
-        return self.compare_op_impl(self.regex.match, other)
+        logger.debug("Regular expression match: %s == %s",
+            self.equality_regex, other)
+        return self.compare_op_impl(self.equality_regex.match, other)
 
     def __ne__(self, other):
         """ Implement inequality using re.match """
-        logger.debug("Regular expression match: %s != %s", self.regex, other)
-        return not self.compare_op_impl(self.regex.match, other)
+        logger.debug("Regular expression match: %s != %s",
+            self.equality_regex, other)
+        return not self.compare_op_impl(self.equality_regex.match, other)
 
     def __contains__(self, other):
         """ Implement membership using re.search """
-        logger.debug("Regular expression search: %s in %s", self.regex, other)
-        return self.compare_op_impl(self.regex.search, other)
+        logger.debug("Regular expression search: %s in %s",
+            self.membership_regex, other)
+        return self.compare_op_impl(self.membership_regex.search, other)
 
 
 class EvalRegex(EvalBase):

--- a/tests/test.py
+++ b/tests/test.py
@@ -1141,6 +1141,11 @@ unknown : baz'''
         result = rule.evaluate(sample)
         self.assertEqual(result.result, Result.unknown)
 
+        part["name_declared"] = "smime.p7sm"
+        sample = factory.make_sample('', metainfo=part)
+        result = rule.evaluate(sample)
+        self.assertEqual(result.result, Result.unknown)
+
         part["name_declared"] = "file"
         sample = factory.make_sample('', metainfo=part)
         result = rule.evaluate(sample)
@@ -1652,19 +1657,30 @@ class TestExpressionParser(unittest.TestCase):
             ["'foo' == 'bar'", False],
             ["'foo' == 'foo'", True],
             ["'foo' in 'bar'", False],
-            # re.search()
+            # re.search() for "match anywhere in operand"
             ["'foo' in 'foobar'", True],
             ["/foo/ in 'afoobar'", True],
-            # re.match() is implicit /^<pattern>/
+            # re.match() is implicit /^<pattern>/. We add $ at the end to have
+            # "match from beginning to end"
             ["/foo/ == 'afoobar'", False],
-            ["/foo/ == 'foobar'", True],
-            ["/foo/ != 'foobar'", False],
+            ["/foo/ == 'foo'", True],
+            ["/foo/ == 'foobar'", False],
+            ["/foo/ == 'fo'", False],
+            ["/foo/ == 'foob'", False],
+            ["/foo/ == 'fobar'", False],
+            ["/foo/ != 'afoobar'", True],
+            ["/foo/ != 'foo'", False],
+            ["/foo/ != 'foobar'", True],
+            ["/foo/ != 'fo'", True],
+            ["/foo/ != 'foob'", True],
             ["/foo/ != 'fobar'", True],
             ["/[fb][oa][or]/ in 'foo'", True],
             ["/[fb][oa][or]/ in 'bar'", True],
             ["/[fb][oa][or]/ in 'snafu'", False],
             ["/[fb][oa][or]/ in ['afoob', 'snafu']", True],
             ["/[fb][oa][or]/ not in ['afoob', 'snafu']", False],
+            ["/[fb][oa][or]/ == ['foo', 'snafu']", True],
+            ["/[fb][oa][or]/ == ['foob', 'snafu']", False],
             ["/[fb][oa][or]/ == ['afoob', 'snafu']", False],
             ["/[fb][oa][or]/ != ['afoob', 'snafu']", True],
             ["[/foo/, /bar/] in ['snafu', 'fuba']", False],


### PR DESCRIPTION
Equality matching of regexes in expressions is currently implemented
using re.match. This was done purely from the perspective of reflecting
both python matching primitives (re.match and re.search) in a useful
manner in our expression language and we were aware of their behaviour
at the time.

It turns out, however, that this behaviour is neither naturally expected
behaviour when looking at an equality operator nor very useful. It
immediately caught us out when writing our own example ruleset
expressions in that we wrote ignore matches for S/MIME signature
attachments that would look at only the beginning of filenames. This
allows evasion of analysis by simply letting the attachment name begin
with one of the configured patterns.

Change equality machting of regexes to require a match from beginning to
end of the operand by adding an explicit end-of-line anchor to the
regex. We still keep using re.match to keep the change small. Add test
coverage to both basic expression parser as well as expression rule
testing to catch regressuions on this.

It could be considered to later switch to re.search for both operators,
adding the beginning-of-line anchor for re.search explicitly as well.
There is at least one remaining difference in behaviour regarding
multiline mode which we do not currently use, though. We add a
cautionary comment to that effect.