### PR TITLE
SQLAlchemy fix

### DIFF
--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -28,6 +28,7 @@ SQLAlchemy. """
 import threading
 import logging
 from datetime import datetime, timedelta
+import sqlalchemy
 from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, \
         Enum, Index
 from sqlalchemy.ext.declarative import declarative_base
@@ -454,7 +455,8 @@ class PeekabooDatabase(object):
                 'Unable to drop all tables of the database: %s' % error)
 
     def _db_schema_exists(self):
-        if not self.__engine.dialect.has_table(self.__engine, '_meta'):
+        insp = sqlalchemy.inspect(self.__engine)
+        if not insp.has_table('_meta'):
             return False
 
         session = self.__session()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sqlalchemy>=1.1.0
+sqlalchemy>=1.4.0
 Twisted>=17.1.0
 service_identity>=16.0.0
 python-magic>=0.4.12


### PR DESCRIPTION
With version 1.4.0 SQLAlchemy introduced the ``inspect`` object that can check if a
table exists using ``has_table``. Our check leads to the error and the message:
"the Dialect.has_table() method is for internal dialect use only; please use
``inspect(some_engine).has_table(<tablename>>)`` for public API use."

Now the original behaviour is restored pushing the minimal required version of
SQLAlchemy to 1.4.0.
