### PR TITLE
cortex: Improvements on available analysers and attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ See documentation for details.
   security reasons. Reduces the amount of information available in Peekaboo
   processing failure dumps as well. URL to access original report via Cuckoo API
   is provided instead.
+- The CortexAnalyser or more precisely every CortexAnalyser can now access
+  domain, hash, and ip artifacts from within the Generic rules.
+- FileInfoAnalyzerReport has new attibutes md5sum, sha256sum, and ssdeepsum
+  (now don't get to excited, ssdeep hashes can only be used as strings)
 
 ## 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See documentation for details.
   domain, hash, and ip artifacts from within the Generic rules.
 - FileInfoAnalyzerReport has new attibutes md5sum, sha256sum, and ssdeepsum
   (now don't get to excited, ssdeep hashes can only be used as strings)
+- Input validation of reports adds a new pip requirement: schema
 
 ## 2.0
 

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -140,7 +140,9 @@ Attribues of cortexreport
 
 .. code-block:: shell
 
-    FileInfoReport.full
+    FileInfoReport.sha256sum
+    FileInfoReport.md5sum
+    FileInfoReport.ssdeepsum
     HybridAnalysisReport.full
     VirusTotalQueryReport.n_of_all
     VirusTotalQueryReport.level
@@ -148,3 +150,11 @@ Attribues of cortexreport
     CuckooSandboxFileReport.malscore
     CAPEv2FileReport.signatures
     CAPEv2FileReport.malscore
+
+and every cortexreport has these artifacts
+
+.. code-block:: shell
+
+    .domain_artifacts
+    .hash_artifacts
+    .ip_artifacts

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -151,7 +151,7 @@ Attribues of cortexreport
     CAPEv2FileReport.signatures
     CAPEv2FileReport.malscore
 
-and every cortexreport has these artifacts
+and all analyser reports have these artifacts
 
 .. code-block:: shell
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1512,6 +1512,7 @@ unknown : baz'''
                             "submodule_section_header": "Hashes",
                             "submodule_section_content": {
                                 "md5": "78576e618aff135f320601e49bd8fe7e",
+                                "sha256": "A"*64,
                             }
                         },
                     ]
@@ -1554,11 +1555,8 @@ unknown : baz'''
 
         report["full"]["results"][0]["results"][0]["submodule_section_content"]["md5"] = ""
         cortexreport = CortexReport()
-        cortexreport.register_report(FileInfoAnalyzer, report)
-        sample.register_cortex_report(cortexreport)
-        result = rule.evaluate(sample)
-        self.assertEqual(result.result, Result.unknown)
-
+        with self.assertRaisesRegex(TypeError, r'md5 .* long'):
+            cortexreport.register_report(FileInfoAnalyzer, report)
 
     def test_rule_expressions_cortexreport_virustotalqueryreport_context(self):
         """ Test generic rule cortexreport.VirusTotalQueryReport context """


### PR DESCRIPTION
The `CortexAnalyser` or more precisely every `CortexAnalyser` can now access
`Cortex domain, hash, and ip artifacts` from within the Generic rules.

`FileInfoAnalyzerReport` has new attributes `md5sum, sha256sum, and ssdeepsum`
(now don't get to excited, ssdeep hashes can only be used as strings)