### PR TITLE
Better cuckoo report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ See documentation for details.
 - Generic rules can now make use of the new analyser `knownreport`
 - Introduce cortexreport toolbox analyser to connect to Cortex by TheHive.
   There already are a few sub analysers that can be used.
+- Reduce amount of data copied from Cuckoo reports for memory efficiency and
+  security reasons. Reduces the amount of information available in Peekaboo
+  processing failure dumps as well.
 
 ## 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ See documentation for details.
   There already are a few sub analysers that can be used.
 - Reduce amount of data copied from Cuckoo reports for memory efficiency and
   security reasons. Reduces the amount of information available in Peekaboo
-  processing failure dumps as well.
+  processing failure dumps as well. URL to access original report via Cuckoo API
+  is provided instead.
 
 ## 2.0
 

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -94,7 +94,6 @@ Attributes of cuckooreport
 .. code-block:: shell
 
     requested_domains
-    signatures
     signature_descriptions
     score
     errors

--- a/docs/source/ruleset.rst
+++ b/docs/source/ruleset.rst
@@ -98,7 +98,7 @@ Attributes of cuckooreport
     signature_descriptions
     score
     errors
-    cuckoo_server_messages
+    server_messages
 
 Attributes of olereport
 -----------------------

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -566,14 +566,14 @@ class CuckooAnalysisFailedRule(CuckooRule):
         failure_reason = _("Behavioral analysis by Cuckoo has produced "
                            "an error and did not finish successfully")
 
-        for entry in report.cuckoo_server_messages:
+        for entry in report.server_messages:
             for failure in self.failure_matches:
                 if failure in entry:
                     logger.debug('Failure indicator "%s" found in Cuckoo '
                                  'messages', failure)
                     return self.result(Result.failed, failure_reason, False)
 
-        for entry in report.cuckoo_server_messages:
+        for entry in report.server_messages:
             for success in self.success_matches:
                 if success in entry:
                     logger.debug('Success indicator "%s" found in Cuckoo '

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -464,10 +464,9 @@ class CuckooEvilSigRule(CuckooRule):
         sample as bad. """
         # look through matched signatures
         sigs = []
-        for descr in report.signatures:
-            logger.debug("Signature from cuckoo report: %s",
-                         descr['description'])
-            sigs.append(descr['description'])
+        for descr in report.signature_descriptions:
+            logger.debug("Signature from cuckoo report: %s", descr)
+            sigs.append(descr)
 
         # check if there is a "bad" signatures and return bad
         matched_bad_sigs = []

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -358,7 +358,7 @@ class Sample:
                                          filename + '_cuckoo_report.json')
             try:
                 with open(cuckoo_report, 'wb+') as cr_json_file:
-                    cr_json = json.dumps(self.__cuckoo_report.raw,
+                    cr_json = json.dumps(self.__cuckoo_report.dump,
                                          indent=1, ensure_ascii=True)
                     cr_json_file.write(cr_json.encode('ascii'))
             except (OSError, IOError) as error:

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -494,7 +494,7 @@ class CuckooReport:
             return []
 
     @property
-    def cuckoo_server_messages(self):
+    def server_messages(self):
         """
         Messages logged by the Cuckoo server (as opposed to those logged by the
         agent inside the analysis VM).

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -444,16 +444,6 @@ class CuckooReport:
             return []
 
     @property
-    def signatures(self):
-        """
-        Gets the triggered signatures from the Cuckoo report.
-
-        @returns: The triggered signatures from the Cuckoo report or None of
-                  there was an error parsing the Cuckoo report.
-        """
-        return self.report.get('signatures', [])
-
-    @property
     def signature_descriptions(self):
         """
         Gets the description of triggered Cuckoo signatures from report.
@@ -463,7 +453,7 @@ class CuckooReport:
                   Cuckoo report.
         """
         descriptions = []
-        for sig in self.signatures:
+        for sig in self.report.get('signatures', []):
             descriptions.append(sig['description'])
         return descriptions
 

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -501,9 +501,6 @@ class CuckooReport:
 
         @returns: List of messages.
         """
-        if self.errors:
-            logger.warning('Cuckoo produced %d error(s) during processing.',
-                           len(self.errors))
         try:
             return self.report['debug']['cuckoo']
         except KeyError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests>=2.19.0
 configparser
 pyparsing
 cortex4py
+schema

--- a/tests/test.py
+++ b/tests/test.py
@@ -880,7 +880,7 @@ class TestCuckoo(unittest.TestCase):
                 "cuckoo": ["msg1", "msg2"],
             }
         }
-        cuckooreport = CuckooReport(report)
+        cuckooreport = CuckooReport(report, "some://where")
         self.assertEqual(cuckooreport.requested_domains[0], "dom1")
         self.assertEqual(cuckooreport.requested_domains[1], "dom2")
         self.assertEqual(cuckooreport.signature_descriptions[0], "desc1")
@@ -890,8 +890,13 @@ class TestCuckoo(unittest.TestCase):
         self.assertEqual(cuckooreport.errors[1], "error2")
         self.assertEqual(cuckooreport.server_messages[0], "msg1")
         self.assertEqual(cuckooreport.server_messages[1], "msg2")
+        self.assertEqual(cuckooreport.url, "some://where")
+
         # assumes above report is a minimal report
-        self.assertEqual(cuckooreport.dump, report)
+        expected_dump = report.copy()
+        expected_dump.update(
+            {"x-peekaboo": {"origin-url": cuckooreport.url}})
+        self.assertEqual(cuckooreport.dump, expected_dump)
 
     def test_invalid_report(self):
         """ Test that invalid report values are rejected. """


### PR DESCRIPTION
Here are some improvements to the Cuckoo report to showcase what would be involved to implement input validation as suggested in #188. Lightly tested: The testsuite runs. See individual commits for rationale.