### PR TITLE
add exceptions for pEp attachments

### DIFF
--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -34,6 +34,9 @@ whitelist.5 : application/x-pkcs7-signature
 whitelist.6 : application/pkcs7-mime
 whitelist.7 : application/x-pkcs7-mime
 whitelist.8 : text/html
+whitelist.9 : application/pep.sign
+whitelist.10 : application/pep.sync
+whitelist.11 : application/pgp-keys
 
 [file_type_on_greylist]
 greylist.1  : application/octet-stream


### PR DESCRIPTION
whitelist these filetypes to avoid  spinning up a vm for common sync messages on top of pgp.