### PR TITLE
Pid file tuning

### DIFF
--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -12,6 +12,8 @@
 # change socket group and mode to open up client access
 #socket_group     :    <empty>
 #socket_mode      :    0660
+
+# can be set to empty to disable PID file creation
 #pid_file         :    /var/run/peekaboo/peekaboo.pid
 #worker_count     :    3
 #sample_base_dir  :    /tmp

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -152,6 +152,10 @@ class PeekabooDaemonInfrastructure:
     def create_pid_file(self):
         """ Check for stale old and create a new PID file. Look at the socket
         as well. """
+        if not self.pid_file:
+            logger.debug("Creation of PID file is disabled.")
+            return
+
         ourpid = os.getpid()
         if os.path.exists(self.pid_file):
             oldpid = None


### PR DESCRIPTION
These changes allow to disable PID file creation if it's not needed and avoid detecting ourselves as an already running process if the PID file contains our own PID due to re-use and collision.