### PR TITLE
cortex: Update FileInfo analyzer version to 8.0

### DIFF
--- a/peekaboo/toolbox/cortex.py
+++ b/peekaboo/toolbox/cortex.py
@@ -174,7 +174,7 @@ class CortexHashAnalyzer(CortexAnalyzer):
 
 
 class FileInfoAnalyzerReport(CortexAnalyzerReport):
-    """ Represents a Cortex FileInfo_7_0 analysis JSON report. """
+    """ Represents a Cortex FileInfo_8_0 analysis JSON report. """
 
     report_schema = schema.Schema({
         "summary": {
@@ -256,8 +256,8 @@ class FileInfoAnalyzerReport(CortexAnalyzerReport):
 
 
 class FileInfoAnalyzer(CortexFileAnalyzer):
-    """ Interfaces with Cortex Analyzer FileInfo_7_0. """
-    name = 'FileInfo_7_0'
+    """ Interfaces with Cortex Analyzer FileInfo_8_0. """
+    name = 'FileInfo_8_0'
     reportclass = FileInfoAnalyzerReport
 
 


### PR DESCRIPTION
Cortex have updated their FileInfo analyzer to version 8.0 which changes
the name we need to use to access it. So update the version number. No
other changes seem necessary.

This could make us potentially backward-incompatible with older versions
of Cortex. But since the analyzers.json URL is not versioned, it appears
they're fully backward-compatible and easy to update (or even
auto-updated) Cortex-side. So we should address that concern only if it
becomes a problem.

A short review of Cortex's analyzers.json reveals no other version
changes.

@sett17 : fyi