### PR TITLE
Info dump

### DIFF
--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -202,7 +202,7 @@ class Sample:
                              dump_dir, oserr)
                 return
 
-        filename = self.__filename + '-' + self.sha256sum
+        filename = self.sha256sum
 
         logger.debug('%d: Dumping processing info to %s',
                      self.__id, dump_dir)

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -100,7 +100,6 @@ class Sample:
         self.__result = Result.unchecked
         self.__reason = None
         self.__report = []
-        self.__internal_report = []
         self.__sha256sum = None
         self.__file_extension = None
         self.__processing_info_dir = processing_info_dir
@@ -209,10 +208,14 @@ class Sample:
         peekaboo_report = os.path.join(dump_dir, 'report.txt')
         try:
             with open(peekaboo_report, 'w+') as pr_file:
+                pr_file.write('Declared file name: %s\n' % self.__filename)
+                pr_file.write(
+                    'Declared content type: %s\n' % self.__content_type)
+                pr_file.write(
+                    'Declared content disposition: %s\n' %
+                    self.__content_disposition)
                 if self.__report:
                     pr_file.write('\n'.join(self.__report + [""]))
-                if self.__internal_report:
-                    pr_file.write('\n'.join(self.__internal_report + [""]))
         except (OSError, IOError) as error:
             logger.error('Failure to write report file %s: %s',
                          peekaboo_report, error)

--- a/peekaboo/sample.py
+++ b/peekaboo/sample.py
@@ -202,13 +202,11 @@ class Sample:
                              dump_dir, oserr)
                 return
 
-        filename = self.sha256sum
-
         logger.debug('%d: Dumping processing info to %s',
                      self.__id, dump_dir)
 
         # Peekaboo's report
-        peekaboo_report = os.path.join(dump_dir, filename + '_report.txt')
+        peekaboo_report = os.path.join(dump_dir, 'report.txt')
         try:
             with open(peekaboo_report, 'w+') as pr_file:
                 if self.__report:
@@ -222,19 +220,18 @@ class Sample:
 
         # store malicious sample along with the reports
         if self.__result == Result.bad:
-            sample_dump = os.path.join(dump_dir, filename + "_sample.bin")
+            sample_dump = os.path.join(dump_dir, 'sample.bin')
             try:
                 with open(sample_dump, 'wb') as dump_file:
                     dump_file.write(self.__content)
             except (shutil.Error, IOError, OSError) as error:
-                logger.error('Failure to dump sample file %s to dump '
-                             'directory: %s', self.__filename, error)
+                logger.error('Failure to dump sample file to dump '
+                             'directory: %s', error)
                 return
 
         # Cuckoo report
         if self.__cuckoo_report:
-            cuckoo_report = os.path.join(dump_dir,
-                                         filename + '_cuckoo_report.json')
+            cuckoo_report = os.path.join(dump_dir, 'cuckoo_report.json')
             try:
                 with open(cuckoo_report, 'wb+') as cr_json_file:
                     cr_json = json.dumps(self.__cuckoo_report.dump,


### PR DESCRIPTION
These changes avoid an error condition in processing info dump which would cause workers to die with due to an exception if the analysis result of a sample without filename was bad or failed. Also they restore some sample metadata (metainfo) that got lost in the REST API switch.