### PR TITLE
Asyncio

### DIFF
--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -66,13 +66,9 @@
 # SQLite
 #url              :    sqlite:////var/lib/peekaboo/peekaboo.db
 # MySQL (recommended)
-# url             :    mysql+mysqldb://user:password@host/database
+# url             :    mysql://user:password@host/database
 # PostgreSQL
 # url             :    postgresql://user:password@host:port/database
-
-# as a last resort it's possible to override the driver for asyncio database
-# accesses if auto-detection fails.
-# async_driver: aiosqlite
 
 # Enable additional logging by the SQLAlchemy database module beyond Peekaboo's
 # own logging. Can be considered another set of debug logging even beyond

--- a/peekaboo/config.py
+++ b/peekaboo/config.py
@@ -430,7 +430,6 @@ class PeekabooConfig(PeekabooConfigParser):
         self.processing_info_dir = '/var/lib/peekaboo/malware_reports'
         self.report_locale = None
         self.db_url = 'sqlite:////var/lib/peekaboo/peekaboo.db'
-        self.db_async_driver = None
         self.db_log_level = logging.WARNING
         self.config_file = '/opt/peekaboo/etc/peekaboo.conf'
         self.ruleset_config = '/opt/peekaboo/etc/ruleset.conf'
@@ -455,7 +454,6 @@ class PeekabooConfig(PeekabooConfigParser):
             'processing_info_dir': ['global', 'processing_info_dir'],
             'report_locale': ['global', 'report_locale'],
             'db_url': ['db', 'url'],
-            'db_async_driver': ['db', 'async_driver'],
             'db_log_level': ['db', 'log_level', self.LOG_LEVEL],
             'ruleset_config': ['ruleset', 'config'],
             'analyzer_config': ['analyzers', 'config'],

--- a/peekaboo/daemon.py
+++ b/peekaboo/daemon.py
@@ -388,7 +388,20 @@ async def async_main():
 
     sys.exit(0)
 
+
+def get_running_loop():
+    """ provide asyncio.get_running_loop in Python 3.6 """
+    loop = asyncio._get_running_loop()
+    if loop is None:
+        raise RuntimeError('no running event loop')
+    return loop
+
+
 def run():
+    # provide asyncio.get_running_loop in Python 3.6
+    if not hasattr(asyncio, "get_running_loop"):
+        asyncio.get_running_loop = get_running_loop
+
     asyncio.run(async_main())
 
 if __name__ == '__main__':

--- a/peekaboo/db.py
+++ b/peekaboo/db.py
@@ -328,7 +328,7 @@ class PeekabooDatabase:
         """
         sample_info = SampleInfo(
             state=sample.state,
-            sha256sum=sample.sha256sum,
+            sha256sum=await sample.sha256sum,
             file_extension=sample.file_extension,
             analysis_time=datetime.now(),
             result=sample.result,
@@ -413,7 +413,7 @@ class PeekabooDatabase:
                 SampleInfo.id != sample.id).where(
                     SampleInfo.result != Result.failed).filter_by(
                         state=JobState.FINISHED,
-                        sha256sum=sample.sha256sum,
+                        sha256sum=await sample.sha256sum,
                         file_extension=sample.file_extension).order_by(
                             SampleInfo.analysis_time)
 
@@ -501,7 +501,7 @@ class PeekabooDatabase:
         if start_time is None:
             start_time = datetime.utcnow()
 
-        in_flight_marker = InFlightSample(sha256sum=sample.sha256sum,
+        in_flight_marker = InFlightSample(sha256sum=await sample.sha256sum,
                                           instance_id=instance_id,
                                           start_time=start_time)
         attempt = 1
@@ -559,7 +559,7 @@ class PeekabooDatabase:
 
         statement = sqlalchemy.sql.expression.delete(
             InFlightSample).where(
-                InFlightSample.sha256sum == sample.sha256sum).where(
+                InFlightSample.sha256sum == await sample.sha256sum).where(
                     InFlightSample.instance_id == instance_id)
 
         attempt = 1

--- a/peekaboo/ruleset/engine.py
+++ b/peekaboo/ruleset/engine.py
@@ -59,7 +59,8 @@ class RulesetEngine:
         FinalRule
     ]
 
-    def __init__(self, config, job_queue, db_con, analyzer_config):
+    def __init__(self, config, job_queue, db_con, analyzer_config,
+                 threadpool=None):
         """ Create the engine and store its config. Postpone lengthy
         initialisation for later so that it can be registered quickly for
         shutdown requests.
@@ -79,6 +80,7 @@ class RulesetEngine:
         self.job_queue = job_queue
         self.db_con = db_con
         self.analyzer_config = analyzer_config
+        self.threadpool = threadpool
         self.cuckoo = None
         self.cortex = None
         self.rules = []
@@ -127,7 +129,8 @@ class RulesetEngine:
         # user-defined rule order is preserved in enabled_rules and through
         # ordered append() in self.rules
         for rule_name in enabled_rules:
-            rule = rule_classes[rule_name](self.config, self.db_con)
+            rule = rule_classes[rule_name](
+                self.config, self.db_con, self.threadpool)
 
             # check if the rule requires any common, long lived logic and
             # instantiate now

--- a/peekaboo/ruleset/engine.py
+++ b/peekaboo/ruleset/engine.py
@@ -85,7 +85,7 @@ class RulesetEngine:
 
         self.shutdown_requested = False
 
-    def start(self):
+    async def start(self):
         """ Initialise the engine, validate its and the individual rules'
         configuration.
 
@@ -143,7 +143,7 @@ class RulesetEngine:
                         self.analyzer_config.cuckoo_submit_original_filename,
                         self.analyzer_config.cuckoo_maximum_job_age)
 
-                    if not self.cuckoo.start_tracker():
+                    if not await self.cuckoo.start_tracker():
                         raise PeekabooRulesetConfigError(
                             "Failure to initialize Cuckoo job tracker")
 
@@ -163,7 +163,7 @@ class RulesetEngine:
                         self.analyzer_config.cortex_submit_original_filename,
                         self.analyzer_config.cortex_maximum_job_age)
 
-                    if not self.cortex.start_tracker():
+                    if not await self.cortex.start_tracker():
                         raise PeekabooRulesetConfigError(
                             "Failure to initialize Cortex job tracker")
 
@@ -181,7 +181,7 @@ class RulesetEngine:
         if self.shutdown_requested:
             self.shut_down_resources()
 
-    def run(self, sample):
+    async def run(self, sample):
         """ Run all the rules in the ruleset against a given sample
 
         @param sample: sample to evaluate ruleset against
@@ -191,7 +191,7 @@ class RulesetEngine:
             logger.debug("%d: Processing rule '%s'", sample.id, rule_name)
 
             try:
-                result = rule.evaluate(sample)
+                result = await rule.evaluate(sample)
                 sample.add_rule_result(result)
             except PeekabooAnalysisDeferred:
                 # in case the Sample is requesting the Cuckoo report
@@ -228,10 +228,10 @@ class RulesetEngine:
         self.shutdown_requested = True
         self.shut_down_resources()
 
-    def close_down(self):
+    async def close_down(self):
         """ Finalize ruleset engine shutdown synchronously. """
         if self.cuckoo is not None:
-            self.cuckoo.close_down()
+            await self.cuckoo.close_down()
 
         if self.cortex is not None:
-            self.cortex.close_down()
+            await self.cortex.close_down()

--- a/peekaboo/server.py
+++ b/peekaboo/server.py
@@ -269,8 +269,8 @@ class PeekabooServer:
             # 'report': report,
             }, 200)
 
-    async def serve(self):
-        """ Serves requests until shutdown is requested from the outside. """
+    async def start(self):
+        """ Makes the server start serving requests. """
         self.server = await self.server_coroutine
 
         # sanic 21.9 introduced an explicit startup that finalizes the app,
@@ -281,8 +281,6 @@ class PeekabooServer:
         await self.server.start_serving()
         logger.info('Peekaboo server is now listening on %s:%d',
                     self.host, self.port)
-        await self.server.wait_closed()
-        logger.debug('Server shut down.')
 
     def shut_down(self):
         """ Triggers a shutdown of the server, used by the signal handler and
@@ -290,3 +288,10 @@ class PeekabooServer:
         logger.debug('Server shutdown requested.')
         if self.server is not None:
             self.server.close()
+
+    async def close_down(self):
+        """ Wait for the server to close down. """
+        if self.server is not None:
+            await self.server.wait_closed()
+
+        logger.debug('Server shut down.')

--- a/peekaboo/toolbox/cortex.py
+++ b/peekaboo/toolbox/cortex.py
@@ -769,7 +769,7 @@ class Cortex:
         """ Start tracking running jobs in a separate thread. """
         self.tracker = asyncio.ensure_future(self.track())
         self.tracker.set_name("CortexJobTracker")
-        return True
+        return self.tracker
 
     async def track(self):
         """ Do the polling for finished jobs. """
@@ -858,5 +858,9 @@ class Cortex:
             # we cancelled the task so a CancelledError is expected
             except asyncio.CancelledError:
                 pass
+            except Exception:
+                logger.exception(
+                    "Unexpected exception in Cortex job tracker")
 
         await self.session.close()
+        logger.debug("Cortex job tracker shut down.")

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -339,7 +339,7 @@ class Cuckoo:
         """ Start tracking running jobs in a separate thread. """
         self.tracker = asyncio.ensure_future(self.track())
         self.tracker.set_name("CuckooJobTracker")
-        return True
+        return self.tracker
 
     async def track(self):
         """ Do the polling for finished jobs. """
@@ -401,8 +401,12 @@ class Cuckoo:
             # we cancelled the task so a CancelledError is expected
             except asyncio.CancelledError:
                 pass
+            except Exception:
+                logger.exception(
+                    "Unexpected exception in Cuckoo job tracker")
 
         await self.session.close()
+        logger.debug("Cuckoo job tracker shut down.")
 
 
 class CuckooReport:

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -305,7 +305,7 @@ class Cuckoo:
             sample.mark_cuckoo_failure()
             await self.job_queue.submit(sample)
 
-    def submit(self, sample):
+    async def submit(self, sample):
         """ Submit a sample to Cuckoo for analysis.
         @param sample: Sample to submit.
         @type sample: Sample
@@ -313,7 +313,7 @@ class Cuckoo:
         @raises: CuckooSubmitFailedException if submission failed
         @returns: ID of the submitted Cuckoo job.
         """
-        filename = sample.sha256sum
+        filename = await sample.sha256sum
 
         # append file extension to aid cuckoo in file type detection
         if sample.file_extension:

--- a/peekaboo/toolbox/known.py
+++ b/peekaboo/toolbox/known.py
@@ -38,13 +38,13 @@ class Knowntools:
         self.sample = sample
         self.db_con = db_con
 
-    def get_report(self):
+    async def get_report(self):
         """ Return knowntools report or create if not already cached. """
         if self.sample.knowntools_report is not None:
             return self.sample.knowntools_report
 
         ktreport = KnowntoolsReport(
-            self.db_con.analysis_journal_fetch_journal(self.sample)
+            await self.db_con.analysis_journal_fetch_journal(self.sample)
         )
 
         self.sample.register_knowntools_report(ktreport)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 aiofiles>=0.8.0
+aiohttp
 sqlalchemy[asyncio]>=1.4.24
+tenacity
 python-magic>=0.4.17
 oletools>=0.54
 sdnotify>=0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles>=0.8.0
 sqlalchemy[asyncio]>=1.4.24
 python-magic>=0.4.17
 oletools>=0.54


### PR DESCRIPTION
These changes switch the rest of Peekaboo beyond the sanic server to asyncio to avoid the symptoms stemming from interaction of threading and asyncio we've seen (e.g. #205). Multiprocessing is maintained through threadpool.

This is meant for discussion and inclusion early in the 2.2 cycle to give us time for testing and improvements.