### PR TITLE
config: Support drop files

### DIFF
--- a/peekaboo.conf.sample
+++ b/peekaboo.conf.sample
@@ -25,6 +25,20 @@
 # order applies.
 #report_locale    :    <unset>
 
+# main configuration file may contain options in global section that configure
+# drop-file read behaviour
+
+# available format specifiers:
+# - config_path: full path of the main configuration file
+# - config_file: basename of the main configuration file
+# - config_dir: directory containing the main configuration file
+#drop_dir_template: {config_path}.d
+
+# drop files are sorted lexicographically before being read. Therefore, a
+# leading (constant length!) numbering or ordering scheme allows to govern read
+# order. Making it part of the globbing pattern is not required and only
+# provides some more robustness regarding stray files and typos.
+#drop_file_glob: [0-9][0-9]-*.conf
 
 [ruleset]
 #config           :    /opt/peekaboo/etc/ruleset.conf

--- a/ruleset.conf.sample
+++ b/ruleset.conf.sample
@@ -19,6 +19,18 @@ rule.11  : cuckoo_analysis_failed
 #rule.12 : contains_peekabooyar
 rule.12 : final_rule
 
+# special syntax for resetting lists: distinguisher - (dash) *and* value -
+# (dash). This can be used in drop files to clear a list and start from
+# scratch.
+#rule.-: -
+
+# Distinguishers of list items (even though suggested by their typical use
+# here) are not indices into an array, are required to be unique only within a
+# single file and items are only ever appended to lists. Since distinguishers
+# are not interpreted beyond above special reset syntax, they can *not* be used
+# to seletively replace list items from drop files. If replacement is required,
+# the list can be reset and rebuilt from scratch.
+
 # rule specific configuration options
 # the section name equals the name of the rule
 #[file_larger_than]

--- a/tests/test.py
+++ b/tests/test.py
@@ -134,6 +134,13 @@ option2.2: baz
 rule.1 : rule1
 #rule.2 : rule2
 rule.3 : rule3
+
+[resettest]
+reset.1: val1
+reset.2: val2
+reset.-: -
+reset.3: val3
+reset.4: val4
 ''')
 
     def test_2_values(self):
@@ -144,6 +151,8 @@ rule.3 : rule3
         self.assertEqual(self.config['rule1'].getoctal('octal'), 0o0717)
         self.assertEqual(self.config['rule1'].getlist('option2'),
                          ['bar', 'baz'])
+        self.assertEqual(self.config['resettest'].getlist('reset'),
+                         ['val3', 'val4'])
 
     def test_3_type_mismatch(self):
         """ Test correct error is thrown if the option type is mismatched """
@@ -194,12 +203,26 @@ class TestConfigDropFiles(unittest.TestCase):
 [section1]
 option1: value2
 option3: value3
+list1.1: value1appended
+list1.2: value2appended
+list1.3: value3appended
+
+[resettest]
+reset.-: -
+reset.1: value1reset
+reset.10: value2reset
 ''')
 
         cls.config = CreatingConfigParser('''
 [section1]
 option1: value1
 option2: value2
+list1.1: value1
+list1.2: value2
+
+[resettest]
+reset.1: value1
+reset.2: value2
 ''', filename=cls.created_config_file)
 
         cls.custom_drop_dir = tempfile.mkdtemp(suffix='.drop')
@@ -225,6 +248,11 @@ option2: value2
         self.assertEqual(self.config['section1']['option1'], 'value2')
         self.assertEqual(self.config['section1']['option2'], 'value2')
         self.assertEqual(self.config['section1']['option3'], 'value3')
+        self.assertEqual(self.config['section1'].getlist('list1'), [
+            'value1', 'value2',
+            'value1appended', 'value2appended', 'value3appended'])
+        self.assertEqual(self.config['resettest'].getlist(
+            'reset'), ['value1reset', 'value2reset'])
 
     def test_2_drop_file_sorting(self):
         """ Test drop file sorting. """


### PR DESCRIPTION
Add functionality to load additional drop-in config snippets from a
directory ending in .d next to the main configuration file. This allows
to separate a distributed default config from local changes. Drop files
have to be named using leading double digits and a trailing .conf by
default. The former allows for lexicographical sorting determining the
order in which the snippets are read and option values overwrite each
other.

Two new global options allow customisation of the drop file directory
template and drop file globbing pattern. The test suite and main config
file sample are extended to match.

Because the logic is implemented in PeekabooConfigParser, it works with
all config files, not only the main peekaboo.conf.

Closes #69.

This logic is meant to simplify our installer, docker compose and k8s use-cases as well. Respective PRs to follow.