### PR TITLE
ci: Switch to latest devel version of Installer

### DIFF
--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -15,8 +15,7 @@ jobs:
       - name: Checkout PeekabooAV-Installer
         uses: actions/checkout@v2
         with:
-          repository: michaelweiser/PeekabooAV-Installer
-          ref: pipeline
+          repository: scVENUS/PeekabooAV-Installer
 
       # put PeekabooAV below that as expected by the installer
       - name: Checkout PeekabooAV


### PR DESCRIPTION
With the compose pipeline fully merged and even improved regarding
recent rspamd changes we can switch to devel HEAD of the Installer
instead of the now outdated pipeline branch (of one developer's private
fork no less).