### PR TITLE
Container image

### DIFF
--- a/.github/actions/container-image-publish/action.yml
+++ b/.github/actions/container-image-publish/action.yml
@@ -1,0 +1,246 @@
+name: Container image publish
+description: Build and publish container image
+
+inputs:
+  ref:
+    required: true
+    description: 'ref for which to build the image'
+  base-ref:
+    required: false
+    description: 'base ref of a pull request'
+  latest:
+    required: false
+    default: false
+    description: >
+      This is the latest release overall and therefore gets the latest tag
+  latest-major:
+    required: false
+    default: false
+    description: >
+      This is the latest in a major release series and therefore gets the major
+      version tag
+  event:
+    required: false
+    default: ${{ github.event_name }}
+    description: 'The event that triggered the build'
+  registry:
+    required: false
+    default: ghcr.io
+    description: 'Container registry to use'
+  registry_username:
+    required: false
+    default: ${{ github.actor }}
+    description: 'User name to use for login to the registry'
+  registry_password:
+    required: true
+    description: 'Password to use for login to the registry'
+  image_name:
+    required: false
+    default: ${{ github.repository }}
+    description: 'Name of the image to build in <account>/<repo> syntax'
+
+runs:
+  using: composite
+  steps:
+    # Dockerfile and its dependencies live in the Installer
+    - name: Checkout Installer repository
+      uses: actions/checkout@v3
+      with:
+        repository: scVENUS/PeekabooAV-Installer
+        # get all history, branches and tags because we figure out which to
+        # use later on
+        fetch-depth: 0
+
+    - name: Select Installer version
+      env:
+        REF: ${{ inputs.ref }}
+        BASE_REF: ${{ inputs.base-ref }}
+      shell: bash
+      run: |
+        # for pull requests decide which Installer version to use based on the
+        # target branch
+        if [ -z "${REF%refs/pull/*}" -a -n "$BASE_REF" ] ; then
+          echo "::notice::Considering base ref $BASE_REF of $REF"
+          REF=refs/heads/$BASE_REF
+        fi
+
+        # use the Installers's devel branch when triggered on our devel
+        # branch - so we just don't do anything here
+        if [ "$REF" = refs/heads/master ] ; then
+          echo "::notice::Staying on devel branch"
+          exit 0
+        fi
+
+        # use the latest corresponding Installer point release when
+        # triggered on a tag or release branch, split these up if the
+        # Installer starts using release branches as well
+        if echo "$REF" | grep \
+              -e '^refs/tags/v[0-9]\+\.[0-9]\+' \
+              -e '^refs/heads/[0-9]\+\.[0-9]\+$' \
+            > /dev/null ; then
+          prelease=${REF#refs/heads/}
+          prelease=${prelease#refs/tags/v}
+
+          # drop point release
+          echo "$prelease" | grep '^[0-9]\+\.[0-9]\+\.[0-9]\+$' > /dev/null && \
+            prelease=${prelease%.[0-9]*}
+
+          venv=$(mktemp -d)
+          python3 -mvenv "$venv"
+          "$venv"/bin/pip install packaging
+
+          # look for installer point release to use
+          findrel=$(mktemp)
+          cat <<EOF | sed -e "s,^    ,," > "$findrel"
+            import sys
+            import packaging.version
+
+            versions=[]
+            for line in sys.stdin:
+              if line.startswith('v$prelease'):
+                versions.append(packaging.version.parse(line))
+
+            if versions:
+              versions = sorted(versions, reverse=True)
+              print(versions[0])
+        EOF
+
+          irelease=$(git tag | "$venv"/bin/python3 "$findrel")
+
+          # stay on devel branch of installer if no matching release can be
+          # found
+          if [ -z "$irelease" ] ; then
+            echo "::notice::No matching Installer version found - " \
+              "staying on devel branch"
+            exit 0
+          fi
+
+          git checkout v"$irelease"
+          exit 0
+        fi
+
+        # fail loudly in unsupported case
+        exit 1
+
+    # put PeekabooAV below that as expected by the installer
+    - name: Check out PeekabooAV
+      uses: actions/checkout@v3
+      with:
+        path: PeekabooAV
+        # for scheduled builds, github.ref/$GITHUB_REF is always latest commit
+        # on default branch
+        ref: ${{ inputs.ref }}
+
+    # Install the cosign tool except on PR
+    # https://github.com/sigstore/cosign-installer
+    - name: Install cosign
+      if: inputs.event != 'pull_request'
+      uses: sigstore/cosign-installer@v2.3.0
+
+    # Workaround: https://github.com/docker/build-push-action/issues/461
+    - name: Setup Docker buildx
+      uses: docker/setup-buildx-action@v2
+
+    # Login against a Docker registry except on PR
+    # https://github.com/docker/login-action
+    - name: Log into registry ${{ inputs.registry }}
+      if: inputs.event != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.registry_username }}
+        password: ${{ inputs.registry_password }}
+
+    - name: Select image tagging scheme
+      id: tags
+      env:
+        REF: ${{ inputs.ref }}
+        LATEST_MAJOR: ${{ inputs.latest-major }}
+      shell: bash
+      run: |
+        # use pep440/semver versioning, particularly only moving latest to
+        # release versions (no prerelease and no branches).
+        # build edge from last commit on devel branch
+        echo "::notice::Defaulting to pep440/edge/ref tagging scheme"
+        tags="type=pep440,pattern={{version}}
+          type=edge
+          type=ref,event=branch
+          type=ref,event=pr"
+
+        if [ "$LATEST_MAJOR" = "true" ] ; then
+          echo "::notice::Release is latest major version"
+          tags="$tags
+            type=pep440,pattern={{major}}"
+        fi
+
+        # build release branch edges
+        if echo "$REF" | grep \
+              -e '^refs/heads/[0-9]\+\.[0-9]\+$' \
+            > /dev/null ; then
+          echo "::notice::Switching to release edge tagging scheme"
+          tags="type=ref,event=branch,suffix=-edge"
+        fi
+
+        # preserve newlines
+        tags=${tags//$'\n'/'%0A'}
+
+        echo "::set-output name=tags::$tags"
+
+    # Extract metadata (tags, labels) for Docker
+    # https://github.com/docker/metadata-action
+    - name: Extract Docker metadata
+      id: meta
+      uses: michaelweiser/metadata-action@ref-input
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.image_name }}
+        tags: |
+          ${{ steps.tags.outputs.tags }}
+        ref: ${{ inputs.ref }}
+        # tagging-triggered builds never move the latest tag. Instead we wait
+        # for the next scheduled image rebuild because it has the overview what
+        # the latest version actually is.
+        flavor: |
+          latest=${{ inputs.latest }}
+
+    # Build and push Docker image with Buildx (don't push on PR)
+    # https://github.com/docker/build-push-action
+    - name: Build and push Docker image
+      id: build-and-push
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: ${{ inputs.event != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    # metadata-action sanitizes the image name but doesn't communicate it
+    # separately, extract it from tags, contains registry as a boon
+    - name: Get sanitized image name
+      id: imagename
+      env:
+        TAGS: ${{ steps.meta.outputs.tags }}
+      shell: bash
+      run: |
+        # we assume here that all tags use the same image name
+        imagename=$(echo "$TAGS" | head -1 | cut -d: -f 1)
+        echo "::set-output name=imagename::$imagename"
+
+        # diagnostics
+        echo "::group::Extracted image name"
+        echo "$imagename"
+        echo "::endgroup::"
+
+    # Sign the resulting Docker image digest except on PRs.
+    # This will only write to the public Rekor transparency log when the
+    # Docker repository is public to avoid leaking data. If you would like
+    # to publish transparency data even for private images, pass --force to
+    # cosign below.  https://github.com/sigstore/cosign
+    - name: Sign the published Docker image
+      if: ${{ inputs.event != 'pull_request' }}
+      env:
+        COSIGN_EXPERIMENTAL: "true"
+      # This step uses the identity token to provision an ephemeral
+      # certificate against the sigstore community Fulcio instance.
+      shell: bash
+      run: cosign sign ${{ steps.imagename.outputs.imagename }}@${{
+        steps.build-and-push.outputs.digest }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       # Checks-out PeekabooAV-Installer under $GITHUB_WORKSPACE
       - name: Checkout PeekabooAV-Installer
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: scVENUS/PeekabooAV-Installer
 
       # put PeekabooAV below that as expected by the installer
       - name: Checkout PeekabooAV
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: PeekabooAV
 

--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -11,11 +11,6 @@ on:
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -27,183 +22,19 @@ jobs:
       id-token: write
 
     steps:
-      # Dockerfile and its dependencies live in the Installer
-      - name: Checkout Installer repository
-        uses: actions/checkout@v3
-        with:
-          repository: scVENUS/PeekabooAV-Installer
-          # get all history, branches and tags because we figure out which to
-          # use later on
-          fetch-depth: 0
-
-      - name: Select Installer version
-        run: |
-          # for pull requests decide which Installer version to use based on the
-          # target branch
-          if [ -z "${GITHUB_REF%refs/pull/*}" -a -n "$GITHUB_BASE_REF" ] ; then
-            echo "::notice::Considering base ref $GITHUB_BASE_REF" \
-              "of $GITHUB_REF"
-            GITHUB_REF=refs/heads/$GITHUB_BASE_REF
-          fi
-
-          # use the Installers's devel branch when triggered on our devel
-          # branch - so we just don't do anything here
-          if [ "$GITHUB_REF" = refs/heads/master ] ; then
-            echo "::notice::Staying on devel branch"
-            exit 0
-          fi
-
-          # use the latest corresponding Installer point release when
-          # triggered on a tag or release branch, split these up if the
-          # Installer starts using release branches as well
-          if echo "$GITHUB_REF" | grep \
-                -e '^refs/tags/v[0-9]\+\.[0-9]\+' \
-                -e '^refs/heads/[0-9]\+\.[0-9]\+$' \
-              >/dev/null ; then
-            # GITHUB_REF_NAME is no good since we tamper with GITHUB_REF above
-            prelease=${GITHUB_REF#refs/heads/}
-            prelease=${prelease#refs/tags/v}
-
-            # drop point release
-            echo "$prelease" | grep '^[0-9]\+\.[0-9]\+\.[0-9]\+$' && \
-              prelease=${prelease%.[0-9]*}
-
-            venv=$(mktemp -d)
-            python3 -mvenv "$venv"
-            "$venv"/bin/pip install packaging
-
-            # look for installer point release to use
-            findrel=$(mktemp)
-            cat <<EOF | sed -e "s,^    ,," > "$findrel"
-              import sys
-              import packaging.version
-
-              versions=[]
-              for line in sys.stdin:
-                if line.startswith('v$prelease'):
-                  versions.append(packaging.version.parse(line))
-
-              if versions:
-                versions = sorted(versions, reverse=True)
-                print(versions[0])
-          EOF
-
-            irelease=$(git tag | "$venv"/bin/python3 "$findrel")
-
-            # stay on devel branch of installer if no matching release can be
-            # found
-            if [ -z "$irelease" ] ; then
-              echo "::notice::No matching Installer version found - " \
-                "staying on devel branch"
-              exit 0
-            fi
-
-            git checkout v"$irelease"
-            exit 0
-          fi
-
-          # fail loudly in unsupported case
-          exit 1
-
-      # put PeekabooAV below that as expected by the installer
+      # required for access to the local publish action
       - name: Check out PeekabooAV
         uses: actions/checkout@v3
         with:
-          path: PeekabooAV
+          path: actions
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v2.3.0
-
-      # Workaround: https://github.com/docker/build-push-action/issues/461
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Select image tagging scheme
-        id: tags
+      - name: Work around checkout action pruning the workspace
+        id: actions
         run: |
-          # use pep440/semver versioning, particularly only moving latest to
-          # release versions (no prerelease and no branches).
-          # build edge from last commit on devel branch
-          echo "::notice::Defaulting to pep440/edge/ref tagging scheme"
-          tags="type=pep440,pattern={{version}}
-            type=pep440,pattern={{major}}.{{minor}}
-            type=edge
-            type=ref,event=branch
-            type=ref,event=pr"
+          cp -a actions/.github/actions/container-image-publish ..
 
-          # build release branch edges
-          if echo "$GITHUB_REF" | grep \
-                -e '^refs/heads/[0-9]\+\.[0-9]\+$' \
-              >/dev/null ; then
-            echo "::notice::Switching to release edge tagging scheme"
-            tags="type=ref,event=branch,suffix=-edge"
-          fi
-
-          # preserve newlines
-          tags=${tags//$'\n'/'%0A'}
-
-          echo "::set-output name=tags::$tags"
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4.0.1
+      - uses: ./../container-image-publish
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            ${{ steps.tags.outputs.tags }}
-
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      # metadata-action sanitizes the image name but doesn't communicate it
-      # separately, extract it from tags, contains registry as a boon
-      - name: Get sanitized image name
-        id: imagename
-        env:
-          TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          # we assume here that all tags use the same image name
-          imagename=$(echo "$TAGS" | head -1 | cut -d: -f 1)
-          echo "::set-output name=imagename::$imagename"
-
-          # diagnostics
-          echo "::group::Extracted image name"
-          echo "$imagename"
-          echo "::endgroup::"
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the
-      # Docker repository is public to avoid leaking data. If you would like
-      # to publish transparency data even for private images, pass --force to
-      # cosign below.  https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral
-        # certificate against the sigstore community Fulcio instance.
-        run: cosign sign ${{ steps.imagename.outputs.imagename }}@${{
-          steps.build-and-push.outputs.digest }}
+          ref: ${{ github.ref }}
+          base-ref: ${{ github.base_ref }}
+          registry_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -1,0 +1,209 @@
+name: Build and publish container image
+
+on:
+  push:
+    branches: [ master, '[0-9]+.[0-9]+' ]
+    # Publish semver tags as releases.
+    tags: [ 'v[0-9]+.[0-9]+*', 'v[0-9]+.[0-9]+.[0-9]+*' ]
+  pull_request:
+    branches: [ master, '[0-9]+.[0-9]+' ]
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      # Dockerfile and its dependencies live in the Installer
+      - name: Checkout Installer repository
+        uses: actions/checkout@v3
+        with:
+          repository: scVENUS/PeekabooAV-Installer
+          # get all history, branches and tags because we figure out which to
+          # use later on
+          fetch-depth: 0
+
+      - name: Select Installer version
+        run: |
+          # for pull requests decide which Installer version to use based on the
+          # target branch
+          if [ -z "${GITHUB_REF%refs/pull/*}" -a -n "$GITHUB_BASE_REF" ] ; then
+            echo "::notice::Considering base ref $GITHUB_BASE_REF" \
+              "of $GITHUB_REF"
+            GITHUB_REF=refs/heads/$GITHUB_BASE_REF
+          fi
+
+          # use the Installers's devel branch when triggered on our devel
+          # branch - so we just don't do anything here
+          if [ "$GITHUB_REF" = refs/heads/master ] ; then
+            echo "::notice::Staying on devel branch"
+            exit 0
+          fi
+
+          # use the latest corresponding Installer point release when
+          # triggered on a tag or release branch, split these up if the
+          # Installer starts using release branches as well
+          if echo "$GITHUB_REF" | grep \
+                -e '^refs/tags/v[0-9]\+\.[0-9]\+' \
+                -e '^refs/heads/[0-9]\+\.[0-9]\+$' \
+              >/dev/null ; then
+            # GITHUB_REF_NAME is no good since we tamper with GITHUB_REF above
+            prelease=${GITHUB_REF#refs/heads/}
+            prelease=${prelease#refs/tags/v}
+
+            # drop point release
+            echo "$prelease" | grep '^[0-9]\+\.[0-9]\+\.[0-9]\+$' && \
+              prelease=${prelease%.[0-9]*}
+
+            venv=$(mktemp -d)
+            python3 -mvenv "$venv"
+            "$venv"/bin/pip install packaging
+
+            # look for installer point release to use
+            findrel=$(mktemp)
+            cat <<EOF | sed -e "s,^    ,," > "$findrel"
+              import sys
+              import packaging.version
+
+              versions=[]
+              for line in sys.stdin:
+                if line.startswith('v$prelease'):
+                  versions.append(packaging.version.parse(line))
+
+              if versions:
+                versions = sorted(versions, reverse=True)
+                print(versions[0])
+          EOF
+
+            irelease=$(git tag | "$venv"/bin/python3 "$findrel")
+
+            # stay on devel branch of installer if no matching release can be
+            # found
+            if [ -z "$irelease" ] ; then
+              echo "::notice::No matching Installer version found - " \
+                "staying on devel branch"
+              exit 0
+            fi
+
+            git checkout v"$irelease"
+            exit 0
+          fi
+
+          # fail loudly in unsupported case
+          exit 1
+
+      # put PeekabooAV below that as expected by the installer
+      - name: Check out PeekabooAV
+        uses: actions/checkout@v3
+        with:
+          path: PeekabooAV
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v2.3.0
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Select image tagging scheme
+        id: tags
+        run: |
+          # use pep440/semver versioning, particularly only moving latest to
+          # release versions (no prerelease and no branches).
+          # build edge from last commit on devel branch
+          echo "::notice::Defaulting to pep440/edge/ref tagging scheme"
+          tags="type=pep440,pattern={{version}}
+            type=pep440,pattern={{major}}.{{minor}}
+            type=edge
+            type=ref,event=branch
+            type=ref,event=pr"
+
+          # build release branch edges
+          if echo "$GITHUB_REF" | grep \
+                -e '^refs/heads/[0-9]\+\.[0-9]\+$' \
+              >/dev/null ; then
+            echo "::notice::Switching to release edge tagging scheme"
+            tags="type=ref,event=branch,suffix=-edge"
+          fi
+
+          # preserve newlines
+          tags=${tags//$'\n'/'%0A'}
+
+          echo "::set-output name=tags::$tags"
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            ${{ steps.tags.outputs.tags }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # metadata-action sanitizes the image name but doesn't communicate it
+      # separately, extract it from tags, contains registry as a boon
+      - name: Get sanitized image name
+        id: imagename
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # we assume here that all tags use the same image name
+          imagename=$(echo "$TAGS" | head -1 | cut -d: -f 1)
+          echo "::set-output name=imagename::$imagename"
+
+          # diagnostics
+          echo "::group::Extracted image name"
+          echo "$imagename"
+          echo "::endgroup::"
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the
+      # Docker repository is public to avoid leaking data. If you would like
+      # to publish transparency data even for private images, pass --force to
+      # cosign below.  https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral
+        # certificate against the sigstore community Fulcio instance.
+        run: cosign sign ${{ steps.imagename.outputs.imagename }}@${{
+          steps.build-and-push.outputs.digest }}

--- a/.github/workflows/publish-container-images-scheduled.yml
+++ b/.github/workflows/publish-container-images-scheduled.yml
@@ -1,0 +1,138 @@
+name: Publish container images (scheduled)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 1 * * *"
+
+jobs:
+  get-refs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PeekabooAV
+        uses: actions/checkout@v3
+        with:
+          # get all history, branches and tags so we can build a list of refs
+          # to build from
+          fetch-depth: 0
+
+      - name: Get refs to build
+        id: refs
+        run: |
+          # in addition to the default branch (which for scheduled workflows is
+          # the GITHUB_REF) we select all release branches and release tags
+          # starting at 2.1
+          refs=$(git show-ref | cut -d" " -f2 | grep \
+              -e "^refs/remotes/origin" \
+              -e "^refs/tags/" \
+            | sed \
+              -e "s,^refs/remotes/origin/,refs/heads/," \
+            | grep \
+              -e "^$GITHUB_REF\$" \
+              -e '^refs/heads/[2-9]\.[1-9][0-9]*$' \
+              -e '^refs/heads/[0-9][0-9]\+\.[0-9]\+$' \
+              -e '^refs/tags/v[2-9]\.[1-9][0-9]*\(\.[0-9]\+\)\?\(rc[0-9]\+\)\?$' \
+              -e '^refs/tags/v[0-9][0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\(rc[0-9]\+\)\?$' \
+            | jq --raw-input --slurp -c 'split("\n") | .[0:-1]')
+          echo "::set-output name=refs::$refs"
+
+          # diagnostics
+          echo "::group::Refs to consider"
+          echo "$refs" | jq
+          echo "::endgroup::"
+
+      - name: Identify latest release ref
+        id: latest
+        env:
+          REFS: ${{ steps.refs.outputs.refs }}
+        shell: python
+        run: |
+          import os
+          import json
+          import sys
+          import packaging.version
+
+          tags = json.loads(os.environ['REFS'])
+          versions=[]
+          majors={}
+          for tag in tags:
+            if not tag.startswith('refs/tags/v'):
+              continue
+
+            tag = tag[len('refs/tags/v'):]
+            version = packaging.version.parse(tag)
+            if version.is_prerelease or version.is_devrelease:
+              continue
+
+            versions.append(version)
+
+            major = version.major
+            if major not in majors:
+              majors[major] = []
+            majors[major].append(version)
+
+          versions = sorted(versions, reverse=True)
+
+          include = [{
+            'latest': False,
+            'latest-major': False,
+          }]
+
+          for major, rels in majors.items():
+            rels = sorted(rels, reverse=True)
+
+            for rel in rels:
+              include.append({
+                'ref': f'refs/tags/v{rel}',
+                'latest': rel is versions[0],
+                'latest-major': rel is rels[0],
+              })
+
+          print("::group::Latest")
+          print(include)
+          print("::endgroup::")
+
+          include_json = json.dumps(include)
+          print(f"::set-output name=include::{include_json}")
+
+    outputs:
+      refs: ${{ steps.refs.outputs.refs }}
+      include: ${{ steps.latest.outputs.include }}
+
+  build-refs:
+    runs-on: ubuntu-latest
+    needs: get-refs
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: ${{ fromJson(needs.get-refs.outputs.refs) }}
+        include: ${{ fromJson(needs.get-refs.outputs.include) }}
+
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      # required for access to the local publish action
+      - name: Check out PeekabooAV
+        uses: actions/checkout@v3
+        with:
+          path: actions
+
+      - name: Work around checkout action pruning the workspace
+        run: |
+          cp -a actions/.github/actions/container-image-publish ..
+
+      # we cannot use a reuseable workflow here because it's not supported in
+      # conjunction with matrix strategy. But a custom action can do exactly
+      # the same and isn't any more complicated. Unfortunately, the separation
+      # of output by steps gets lost on the way.
+      - uses: ./../container-image-publish
+        with:
+          ref: ${{ matrix.ref }}
+          latest: ${{ matrix.latest }}
+          latest-major: ${{ matrix.latest-major }}
+          registry_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testsuite-scheduled.yml
+++ b/.github/workflows/testsuite-scheduled.yml
@@ -19,12 +19,12 @@ jobs:
         branch: ["master", "2.1"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -46,12 +46,12 @@ jobs:
         branch: ["2.0"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -16,10 +16,10 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Add workflows to incrementally and periodically build and publish a container image. Some effort is spent on selecting the right version of the Installer and version tagging during scheduled rebuilds. This is mainly intended to provide automated and well-defined container image releases for our helm chart from scVENUS/PeekabooAV-Installer#77 in the Installer. See https://github.com/michaelweiser/PeekabooAV/pkgs/container/peekabooav/versions for what the resulting image tags look like.

To keep up with Actions updates, we also activate dependabot for them which will open PRs for available updates as it detects them. I got flooded with those in my fork immediately and resolved them by updating to the latest majors (I don't like dependabot's default of providing commit hashes instead of the versions).