### PR TITLE
Knowntools efficiency improvements

### DIFF
--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -242,10 +242,9 @@ class KnownRule(Rule):
         """ Try to get information about the sample from the database. Return
         the old result and reason if found and advise the engine to stop
         processing. """
-        ktreport = self.get_knowntools_report(sample)
-        if ktreport.known:
-            return self.result(
-                ktreport.worst.result, ktreport.worst.reason, False)
+        worst = self.db_con.analysis_journal_get_worst(sample)
+        if worst:
+            return self.result(worst.result, worst.reason, False)
 
         return self.result(Result.unknown,
                            _("File is not yet known to the system"),

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -244,8 +244,8 @@ class KnownRule(Rule):
         processing. """
         ktreport = self.get_knowntools_report(sample)
         if ktreport.known:
-            result, reason = ktreport.worst()
-            return self.result(result, reason, False)
+            return self.result(
+                ktreport.worst.result, ktreport.worst.reason, False)
 
         return self.result(Result.unknown,
                            _("File is not yet known to the system"),

--- a/peekaboo/toolbox/cortex.py
+++ b/peekaboo/toolbox/cortex.py
@@ -497,14 +497,15 @@ class CortexJob:
         @type analyzer: CortexAnalyzer
         """
         self.__sample = sample
-        self.__submission_time = datetime.datetime.utcnow()
+        self.__submission_time = datetime.datetime.now(datetime.timezone.utc)
         self.__analyzer = analyzer
 
     def is_older_than(self, seconds):
         """ Returns True if the difference between submission time and now,
         i.e. the age of the job, is larger than given number of seconds. """
+        now = datetime.datetime.now(datetime.timezone.utc)
         max_age = datetime.timedelta(seconds=seconds)
-        return datetime.datetime.utcnow() - self.__submission_time > max_age
+        return now - self.__submission_time > max_age
 
     @property
     def sample(self):

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -49,13 +49,14 @@ class CuckooJob:
     """ Remember sample and submission time of a Cuckoo job. """
     def __init__(self, sample):
         self.__sample = sample
-        self.__submission_time = datetime.datetime.utcnow()
+        self.__submission_time = datetime.datetime.now(datetime.timezone.utc)
 
     def is_older_than(self, seconds):
         """ Returns True if the difference between submission time and now,
         i.e. the age of the job, is larger than given number of seconds. """
+        now = datetime.datetime.now(datetime.timezone.utc)
         max_age = datetime.timedelta(seconds=seconds)
-        return datetime.datetime.utcnow() - self.__submission_time > max_age
+        return now - self.__submission_time > max_age
 
     @property
     def sample(self):

--- a/peekaboo/toolbox/known.py
+++ b/peekaboo/toolbox/known.py
@@ -24,7 +24,7 @@
 ###############################################################################
 
 import logging
-from datetime import datetime
+import datetime
 
 from peekaboo.ruleset import Result
 
@@ -99,7 +99,7 @@ class KnowntoolsReport:
             return 0
 
         first = self.__first.analysis_time
-        now = datetime.today()
+        now = datetime.datetime.now(datetime.timezone.utc)
         difference = now - first
         return difference.days
 
@@ -111,6 +111,6 @@ class KnowntoolsReport:
             return 0
 
         last = self.__last.analysis_time
-        now = datetime.today()
+        now = datetime.datetime.now(datetime.timezone.utc)
         difference = now - last
         return difference.days

--- a/tests/test.py
+++ b/tests/test.py
@@ -27,6 +27,7 @@
 """ The testsuite. """
 
 import asyncio
+import datetime
 import gettext
 import sys
 import os
@@ -35,7 +36,6 @@ import logging
 import shutil
 import schema
 import unittest
-from datetime import datetime, timedelta
 
 
 # Add Peekaboo to PYTHONPATH
@@ -771,7 +771,8 @@ class TestDatabase(AsyncioTestCase):
 
     def test_8_stale_in_flight(self):
         """ Test the cleaning of stale in-flight markers. """
-        stale = datetime.utcnow() - timedelta(seconds=20)
+        stale = datetime.datetime.now(
+            datetime.timezone.utc) - datetime.timedelta(seconds=20)
         self.assertTrue(self.db_con.mark_sample_in_flight(
             self.sample, 1, stale))
         sample2 = Sample(b'baz', 'baz.pyc')

--- a/tests/test.py
+++ b/tests/test.py
@@ -642,36 +642,58 @@ class TestDatabase(AsyncioTestCase):
     @asynctest
     async def test_3_analysis_journal_fetch_journal(self):
         """ Test retrieval of analysis results. """
+        sample_id = self.sample.id
+
         await self.db_con.analysis_add(self.sample)
         # sample now contains another, new job ID
         # mark sample done so journal and result retrieval tests can work
         self.sample.mark_done()
         self.db_con.analysis_update(self.sample)
 
-        # add a failed analysis to check that it is ignored
+        # add a bad analysis to check that it is worst
         result = RuleResult('Unittest',
-                            Result.failed,
-                            'This is just a test case.',
+                            Result.bad,
+                            'This is just a third test case.',
                             further_analysis=False)
         self.sample.add_rule_result(result)
         await self.db_con.analysis_add(self.sample)
         self.sample.mark_done()
         self.db_con.analysis_update(self.sample)
 
+        # add a failed analysis to check that it is ignored
+        result = RuleResult('Unittest',
+                            Result.failed,
+                            'This is just a second test case.',
+                            further_analysis=False)
+        # new sample with same content so bad result from above does not
+        # dominate result
+        sample = Sample(b'test', 'test.py')
+        sample.add_rule_result(result)
+        await self.db_con.analysis_add(sample)
+        sample.mark_done()
+        self.db_con.analysis_update(sample)
+
         # reset the job id so this sample is not ignored when fetching the
         # journal
         self.sample.update_id(None)
 
-        journal = self.db_con.analysis_journal_fetch_journal(self.sample)
-        self.assertEqual(journal[0].result, Result.good)
-        self.assertEqual(journal[0].reason, 'This is just a test case.')
-        self.assertIsNotNone(journal[0].analysis_time)
-        self.assertEqual(journal[1].result, Result.good)
-        self.assertEqual(journal[1].reason, 'This is just a test case.')
-        self.assertIsNotNone(journal[1].analysis_time)
-        self.assertNotEqual(journal[0].analysis_time, journal[1].analysis_time)
-        # does not contain the failed result
-        self.assertEqual(len(journal), 2)
+        first = self.db_con.analysis_journal_get_first(self.sample)
+        self.assertEqual(first.result, Result.good)
+        self.assertEqual(first.reason, 'This is just a test case.')
+        self.assertIsNotNone(first.analysis_time)
+
+        last = self.db_con.analysis_journal_get_last(self.sample)
+        self.assertEqual(last.result, Result.bad)
+        self.assertEqual(last.reason, 'This is just a third test case.')
+        self.assertIsNotNone(last.analysis_time)
+
+        worst = self.db_con.analysis_journal_get_worst(self.sample)
+        self.assertEqual(worst.result, Result.bad)
+        self.assertEqual(worst.reason, 'This is just a third test case.')
+        self.assertIsNotNone(worst.analysis_time)
+
+        # restore initial ID for further tests
+        self.sample.update_id(sample_id)
 
     @asynctest
     async def test_4_analysis_retrieve(self):
@@ -680,8 +702,8 @@ class TestDatabase(AsyncioTestCase):
         # sample now contains a job ID
         reason, result = await self.db_con.analysis_retrieve(self.sample.id)
         # does not ignore failed analyses like the journal above
-        self.assertEqual(result, Result.failed)
-        self.assertEqual(reason, 'This is just a test case.')
+        self.assertEqual(result, Result.bad)
+        self.assertEqual(reason, 'This is just a third test case.')
 
     def test_5_in_flight_no_cluster(self):
         """ Test that marking of samples as in-flight on a non-cluster-enabled


### PR DESCRIPTION
There is some room for improvement in the way Knowntools uses the database. In quick tests, analysis time of 1000 identical samples would go up from 14s with an empty database to 1m15s with 3000 analyses of this sample already in the database. This seemed to scale linearly, which makes some sense since the sample journal to be downloaded from the database grows linearly as well.

Also, we have different ways of referring to the current time between database, Knowntools and other analysers. I propose to haromise them to UTC and "aware" datetime objects at this opportunity.

A version on top of #210 (which I actually developed on) is at https://github.com/michaelweiser/PeekabooAV/tree/efficient-knowntools.