### PR TITLE
Knowntools efficiency improvements take two

### DIFF
--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -248,10 +248,9 @@ class KnownRule(Rule):
         """ Try to get information about the sample from the database. Return
         the old result and reason if found and advise the engine to stop
         processing. """
-        ktreport = await self.get_knowntools_report(sample)
-        if ktreport.known:
-            return self.result(
-                ktreport.worst.result, ktreport.worst.reason, False)
+        worst = await self.db_con.analysis_journal_get_worst(sample)
+        if worst:
+            return self.result(worst.result, worst.reason, False)
 
         return self.result(Result.unknown,
                            _("File is not yet known to the system"),

--- a/peekaboo/ruleset/rules.py
+++ b/peekaboo/ruleset/rules.py
@@ -250,8 +250,8 @@ class KnownRule(Rule):
         processing. """
         ktreport = await self.get_knowntools_report(sample)
         if ktreport.known:
-            result, reason = ktreport.worst()
-            return self.result(result, reason, False)
+            return self.result(
+                ktreport.worst.result, ktreport.worst.reason, False)
 
         return self.result(Result.unknown,
                            _("File is not yet known to the system"),

--- a/peekaboo/toolbox/cortex.py
+++ b/peekaboo/toolbox/cortex.py
@@ -506,14 +506,15 @@ class CortexJob:
         @type analyzer: CortexAnalyzer
         """
         self.__sample = sample
-        self.__submission_time = datetime.datetime.utcnow()
+        self.__submission_time = datetime.datetime.now(datetime.timezone.utc)
         self.__analyzer = analyzer
 
     def is_older_than(self, seconds):
         """ Returns True if the difference between submission time and now,
         i.e. the age of the job, is larger than given number of seconds. """
+        now = datetime.datetime.now(datetime.timezone.utc)
         max_age = datetime.timedelta(seconds=seconds)
-        return datetime.datetime.utcnow() - self.__submission_time > max_age
+        return now - self.__submission_time > max_age
 
     @property
     def sample(self):

--- a/peekaboo/toolbox/cuckoo.py
+++ b/peekaboo/toolbox/cuckoo.py
@@ -49,13 +49,14 @@ class CuckooJob:
     """ Remember sample and submission time of a Cuckoo job. """
     def __init__(self, sample):
         self.__sample = sample
-        self.__submission_time = datetime.datetime.utcnow()
+        self.__submission_time = datetime.datetime.now(datetime.timezone.utc)
 
     def is_older_than(self, seconds):
         """ Returns True if the difference between submission time and now,
         i.e. the age of the job, is larger than given number of seconds. """
+        now = datetime.datetime.now(datetime.timezone.utc)
         max_age = datetime.timedelta(seconds=seconds)
-        return datetime.datetime.utcnow() - self.__submission_time > max_age
+        return now - self.__submission_time > max_age
 
     @property
     def sample(self):

--- a/peekaboo/toolbox/known.py
+++ b/peekaboo/toolbox/known.py
@@ -24,7 +24,7 @@
 ###############################################################################
 
 import logging
-from datetime import datetime
+import datetime
 
 from peekaboo.ruleset import Result
 
@@ -99,7 +99,7 @@ class KnowntoolsReport:
             return 0
 
         first = self.__first.analysis_time
-        now = datetime.today()
+        now = datetime.datetime.now(datetime.timezone.utc)
         difference = now - first
         return difference.days
 
@@ -111,6 +111,6 @@ class KnowntoolsReport:
             return 0
 
         last = self.__last.analysis_time
-        now = datetime.today()
+        now = datetime.datetime.now(datetime.timezone.utc)
         difference = now - last
         return difference.days

--- a/peekaboo/toolbox/known.py
+++ b/peekaboo/toolbox/known.py
@@ -44,7 +44,9 @@ class Knowntools:
             return self.sample.knowntools_report
 
         ktreport = KnowntoolsReport(
-            await self.db_con.analysis_journal_fetch_journal(self.sample)
+            await self.db_con.analysis_journal_get_first(self.sample),
+            await self.db_con.analysis_journal_get_last(self.sample),
+            await self.db_con.analysis_journal_get_worst(self.sample)
         )
 
         self.sample.register_knowntools_report(ktreport)
@@ -53,63 +55,62 @@ class Knowntools:
 
 class KnowntoolsReport:
     """ Represents a custom Knowntools report. """
-    def __init__(self, sample_journal=None):
-        if sample_journal is None:
-            sample_journal = []
-        self.sample_journal = sample_journal
+    def __init__(self, first=None, last=None, worst=None):
+        self.__first = first
+        self.__last = last
+        self.__worst = worst
 
     def __str__(self):
-        return "<KnowntoolsReport('%s'>" % self.sample_journal
+        return "<KnowntoolsReport(first='%s', last='%s', worst='%s')>" % (
+            self.__first, self.__last, self.__worst)
 
     @property
     def known(self):
         """ Determines if there is a database entry for this sample """
-        return bool(self.sample_journal)
+        return bool(self.__last)
 
     @property
     def last_result(self):
         """ Return the cached result """
-        if self.sample_journal:
-            return self.sample_journal[-1].result
-        return Result.unknown
+        if self.__last is None:
+            return Result.unknown
+
+        return self.__last['result']
+
+    result = last_result
 
     @property
-    def result(self):
-        """ Return the cached result """
-        return self.last_result
-
     def worst(self):
-        """ Return the worst (result, reason) cached """
-        worst_result = Result.unchecked
-        worst_reason = ""
-        for _, result, reason in self.sample_journal:
-            if result > worst_result:
-                worst_result = result
-                worst_reason = reason
-        return (worst_result, worst_reason)
+        """ Return the worst cached result's attribute dict. Can be None. """
+        return self.__worst
 
     @property
     def worst_result(self):
         """ Return the worst result cached """
-        return self.worst()[0]
+        if self.__worst is None:
+            return Result.unknown
+
+        return self.worst.result
 
     @property
     def first(self):
         """ Calculates the age in days since first record of this sample """
-        if self.sample_journal:
-            first = self.sample_journal[0].analysis_time
-            now = datetime.today()
-            difference = now - first
-            return difference.days
-        return 0
+        if self.__first is None:
+            return 0
+
+        first = self.__first.analysis_time
+        now = datetime.today()
+        difference = now - first
+        return difference.days
 
     @property
     def last(self):
         """ Calculates the age in days since most recent record of this
         sample """
-        if self.sample_journal:
-            last = self.sample_journal[-1].analysis_time
-            now = datetime.today()
-            difference = now - last
-            return difference.days
-        return 0
+        if self.__last is None:
+            return 0
+
+        last = self.__last.analysis_time
+        now = datetime.today()
+        difference = now - last
+        return difference.days

--- a/tests/test.py
+++ b/tests/test.py
@@ -27,6 +27,7 @@
 """ The testsuite. """
 
 import asyncio
+import datetime
 import gettext
 import sys
 import os
@@ -35,7 +36,6 @@ import logging
 import shutil
 import schema
 import unittest
-from datetime import datetime, timedelta
 
 
 # Add Peekaboo to PYTHONPATH
@@ -790,7 +790,8 @@ class TestDatabase(AsyncioTestCase):
     @asynctest
     async def test_8_stale_in_flight(self):
         """ Test the cleaning of stale in-flight markers. """
-        stale = datetime.utcnow() - timedelta(seconds=20)
+        stale = datetime.datetime.now(
+            datetime.timezone.utc) - datetime.timedelta(seconds=20)
         self.assertTrue(await self.db_con.mark_sample_in_flight(
             self.sample, 1, stale))
         sample2 = Sample(b'baz', 'baz.pyc')


### PR DESCRIPTION
There is some room for improvement in the way Knowntools uses the database. In quick tests, analysis time of 1000 identical samples would go up from 14s with an empty database to 1m15s with 3000 analyses of this sample already in the database. This seemed to scale linearly, which makes some sense since the sample journal to be downloaded from the database grows linearly as well.

Also, we have different ways of referring to the current time between database, Knowntools and other analysers. I propose to haromise them to UTC and "aware" datetime objects at this opportunity.

Follow-up to #217 based on fully asyncio-converted Peekaboo.