### PR TITLE
Add Mastodon social media account

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 If you run mail on-site, distrust security vendors and need a high level of security and secrecy
 PeekabooAV is for you.
 
-For news and announcements follow us on twitter [@peekabooAV](https://twitter.com/peekabooav).
+For news and announcements follow us on twitter [@peekabooAV](https://twitter.com/peekabooav) and
+Fosstodon [@peekabooav@fosstodon.org](https://fosstodon.org/@peekabooav).
 
 
 


### PR DESCRIPTION
For some time we have an account on Fosstodon
https://fosstodon.org/@peekabooav

Where we independently announce news about the project

As many people now use Mastodon it is time to officially (also) refer to it.