### PR TITLE
Run testsuite on Ubuntu 20.04 for Python 3.6

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -9,11 +9,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest]
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.6"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Github Actions has moved ubuntu-latest to 22.04. This is fine since we test with generic Python versions. But Python 3.6 is no longer provided on 22.04. So we add an exception to the test matrix to run the testsuite on Ubuntu 20.04 for Python 3.6. This is done by way of adding a new matrix variable os which defines the runner image to use. This still defaults to ubuntu-latest. An explicit matrix variable combination is added with ubuntu-20.04 and python version 3.6.